### PR TITLE
[BUG] atlas: open morph no longer snaps the card on a quick close

### DIFF
--- a/avian/frontend/apt.js
+++ b/avian/frontend/apt.js
@@ -2198,6 +2198,8 @@
     }, 0);
     if (start) {
       onceTransformEnd(modalCard, function () {
+        // A close took over (is-open gone); clearing now snaps the card to centre.
+        if (!modal.classList.contains('is-open')) return;
         modalCard.classList.remove('is-morphing');
         modalCard.style.transform = '';
       }, 360);


### PR DESCRIPTION
## Summary
Guard the detail card's open-morph settle so it bails when a close has already taken over (`is-open` removed), instead of clearing the transform out from under the close.

## Why
Closing the Atlas detail card while its open morph is still finishing (~250ms after opening) produced a one-frame snap back to the centred open position. `morphModalOpen`'s settle (`onceTransformEnd`) fires ~360ms after opening on its timeout fallback; if a close started in between, it stripped `is-morphing` and the inline transform mid-close, snapping the card to centre.

Different code path from #3: that fixes the close cleanup interrupting a rapid reopen; this fixes the open cleanup interrupting a close. They are complementary.

## Validation
- `node --check avian/frontend/apt.js`
- Instrumented the close on a local repro: closing ~250ms after opening cleared the transform at opacity 0.33 (visible snap) before, and at opacity 0 (no snap) after. Normal open still settles; close-from-settled unchanged.
