### PR TITLE
[FEAT] collage: empty nest blooms in, and clicking it no longer opens a bird

### DIFF
--- a/avian/frontend/apt.js
+++ b/avian/frontend/apt.js
@@ -412,6 +412,12 @@
 
   function renderCollage(items, animate) {
     collage.innerHTML = '';
+    // Drop the previous render's hit-test tiles up front so a click or hover on
+    // the empty-nest state (or a collage that hasn't laid out yet) resolves to
+    // nothing, not to a stale bird from the last populated render. The populated
+    // path repopulates collagePlaced once the new tiles are placed.
+    collagePlaced = [];
+    collageHovered = null;
     if (!items.length) {
       // No birds heard yet: show an empty nest where the collage would be, with
       // the status line beneath it. The frame (shoot.py) overrides the .empty
@@ -419,6 +425,16 @@
       collage.innerHTML = '<div class="empty-nest">' +
         '<img class="nest-img" src="nest.webp" alt="an empty nest" decoding="async">' +
         '<p class="empty">no birds heard in this window.</p></div>';
+      // Bloom the nest in on the same cues as the collage (first load, window
+      // change, view switch); a silent poll/resize renders without animate. The
+      // class self-clears after the worst case so a throttled tab still ends
+      // with the nest visible, mirroring the tile entrance's safety net.
+      if (animate) {
+        var enest = collage.firstChild;
+        enest.classList.add('entering');
+        clearTimeout(collageEntranceT);
+        collageEntranceT = setTimeout(function () { enest.classList.remove('entering'); }, 900);
+      }
       return;
     }
     var W = collage.clientWidth, H = collage.clientHeight;

--- a/avian/frontend/styles.css
+++ b/avian/frontend/styles.css
@@ -602,6 +602,18 @@
   }
   .empty-nest .nest-img { width: 78%; max-width: 470px; height: auto; }
   .empty-nest .empty { padding: 0; margin: 0; }
+  /* Bloom the empty nest in on the same cues as the collage, reusing the tile
+     keyframe (gtile-in): the nest fades + scales, the status line trails it. */
+  .empty-nest.entering .nest-img {
+    animation: gtile-in 420ms cubic-bezier(.2, .7, .3, 1) backwards;
+  }
+  .empty-nest.entering .empty {
+    animation: gtile-in 420ms cubic-bezier(.2, .7, .3, 1) 130ms backwards;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .empty-nest.entering .nest-img,
+    .empty-nest.entering .empty { animation: none; }
+  }
 
   /* Page header is now shared at .stage > .static-head - see top of CSS. */
   /* Stats grid: charts stack on the LEFT, text sections on the RIGHT.


### PR DESCRIPTION
Two refinements to the no-birds empty state, on top of #25.

Bloom: the empty nest now animates in on the same cues as the collage (first load, window change, view switch), reusing the collage's own `gtile-in` entrance so the motion matches the birds. The status line trails the nest by a beat, and `prefers-reduced-motion` turns it off. A silent poll or resize renders it without the animation, and a self-clearing safety net keeps it visible in a throttled tab, mirroring how the tiles behave.

Click: clicking the empty nest used to open a bird's atlas page. `renderCollage` kept the previous populated render's hit-test tiles, so a click on the empty state resolved to whichever bird last sat under the cursor. `renderCollage` now drops those tiles at the top of every render, and the populated path repopulates them as before. This latent bug predates the nest: the old one-line note had the same invisible tiles behind it, but the nest is inviting enough to actually click.

Verified on a local render of the birdless state: the bloom plays through the tile keyframe and self-clears, and 54 clicks spread across the empty collage all resolve to nothing while a populated collage still hit-tests all 23 tiles.
