### PR TITLE
frame: raise default shoot timeout to 180s (Zero 2 W renders take ~70-120s)

### DIFF
--- a/frame/config.example.toml
+++ b/frame/config.example.toml
@@ -51,7 +51,10 @@ heal_hours = 24        # force a refresh at least this often
 # --- Paths ------------------------------------------------------------------
 state = "~/.birdframe/state.json"
 cache = "~/.birdframe"
-timeout = 45
+# 180s: a Zero 2 W takes ~70-120s to render the collage in headless
+# chromium; the old 45s default made the frame silently never draw on
+# that board (every shoot timed out waiting for tiles).
+timeout = 180
 
 # --- Only if your WHOLE site is behind basic-auth ---------------------------
 # The AvianVisitors default leaves the collage and detection API public, so

--- a/frame/display.py
+++ b/frame/display.py
@@ -59,7 +59,7 @@ DEFAULTS = {
     "heal_hours": 24,
     "state": "~/.birdframe/state.json",
     "cache": "~/.birdframe",
-    "timeout": 45,
+    "timeout": 180,      # seconds; a Zero 2 W needs ~70-120s to shoot the collage
     "basic_user": None, "basic_pass": None,
 }
 

--- a/frame/install.sh
+++ b/frame/install.sh
@@ -123,7 +123,7 @@ shoot_title = "Avian Visitors"
 shoot_subtitle = "Heard Today"
 rotate = 90          # flip to 270 if the frame hangs the other way up
 saturation = 0.6
-timeout = 45
+timeout = 180        # a Zero 2 W needs ~70-120s to shoot the collage
 # If your BirdNET-Pi is behind basic-auth, uncomment and set these:
 # basic_user = "..."
 # basic_pass = "..."


### PR DESCRIPTION
On a Pi Zero 2 W the headless-chromium collage shoot takes ~70–120s (measured on a real board), so the shipped `timeout = 45` means the frame silently never draws: every run logs `could not get image: Page.wait_for_selector: Timeout 45000ms exceeded` and keeps the previous panel image forever. Since kits shipped Zero 2 Ws before the 3 A+ switch, anyone running one is likely hitting this today.

This raises the default (and the example config) to 180s, which covers the slowest renders we observed with margin while still failing fast enough to retry on the next timer tick.

Found on a real frame that had "worked" for days but never once updated until we tailed `journalctl -u birdframe.service`. Running with this value in production since 2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)