### PR TITLE
web: send no-cache on the HTML shell; version-stamp asset URLs

### DIFF
--- a/avian/frontend/index.html
+++ b/avian/frontend/index.html
@@ -10,7 +10,7 @@
 <!-- Apply the saved theme before first paint so dark mode doesn't flash
      light on load. The full switcher lives in Settings (writes bird:theme). -->
 <script>try{if(localStorage.getItem('bird:theme')==='dark')document.documentElement.setAttribute('data-theme','dark');}catch(e){}</script>
-<link rel="stylesheet" href="./styles.css">
+<link rel="stylesheet" href="./styles.css?v=r10">
 </head>
 <body class="av-local">
 <!-- Pill in the top-left slot, only visible on admin overlays
@@ -213,6 +213,6 @@
   </div>
 </section>
 
-<script src="./apt.js"></script>
+<script src="./apt.js?v=r10"></script>
 </body>
 </html>

--- a/avian/frontend/index.html
+++ b/avian/frontend/index.html
@@ -10,7 +10,7 @@
 <!-- Apply the saved theme before first paint so dark mode doesn't flash
      light on load. The full switcher lives in Settings (writes bird:theme). -->
 <script>try{if(localStorage.getItem('bird:theme')==='dark')document.documentElement.setAttribute('data-theme','dark');}catch(e){}</script>
-<link rel="stylesheet" href="./styles.css?v=r10">
+<link rel="stylesheet" href="./styles.css?v=r12">
 </head>
 <body class="av-local">
 <!-- Pill in the top-left slot, only visible on admin overlays
@@ -213,6 +213,6 @@
   </div>
 </section>
 
-<script src="./apt.js?v=r10"></script>
+<script src="./apt.js?v=r12"></script>
 </body>
 </html>

--- a/scripts/update_caddyfile.sh
+++ b/scripts/update_caddyfile.sh
@@ -19,6 +19,11 @@ HASHWORD=$(caddy hash-password --plaintext ${CADDY_PWD})
 cat << EOF > /etc/caddy/Caddyfile
 http:// ${BIRDNETPI_URL} {
   root * ${EXTRACTED}
+  # The HTML shell must always revalidate so UI deploys and re-rendered
+  # illustrations show up on the next load; versioned assets (?v=) keep
+  # caching normally.
+  @shell path / /index.html
+  header @shell Cache-Control "no-cache"
   file_server browse
   handle /By_Date/* {
     file_server browse
@@ -61,6 +66,11 @@ else
   cat << EOF > /etc/caddy/Caddyfile
 http:// ${BIRDNETPI_URL} {
   root * ${EXTRACTED}
+  # The HTML shell must always revalidate so UI deploys and re-rendered
+  # illustrations show up on the next load; versioned assets (?v=) keep
+  # caching normally.
+  @shell path / /index.html
+  header @shell Cache-Control "no-cache"
   file_server browse
   handle /By_Date/* {
     file_server browse


### PR DESCRIPTION
Caddy currently serves everything with no `Cache-Control`, so browsers fall back to heuristic freshness (roughly 10% of a file's age since Last-Modified). In practice a UI change or an illustration re-render can take hours to reach a browser that already has the page cached — and a stale `index.html` mixed with fresh assets renders a broken hybrid.

Two small changes:
- the generated Caddyfile (both variants in `update_caddyfile.sh`) sends `Cache-Control: no-cache` for `/` and `/index.html` — revalidate every load; the existing ETag makes this a cheap 304
- `index.html` references `styles.css`/`apt.js` with the same `?v=` token the app already uses for cutouts, so bumping `SKETCH_VERSION` reliably busts everything at once

🤖 Generated with [Claude Code](https://claude.com/claude-code)