### PR TITLE
[DOCS] Add Iberian bundle to illustration-bundles.md

### DIFF
--- a/illustration-bundles.md
+++ b/illustration-bundles.md
@@ -10,6 +10,7 @@ The main repo ships a Western-US set reviewed by hand. Other people have generat
 
 - **Switzerland (CH-BE)**: [theskyisthelimit's fork](https://github.com/theskyisthelimit/AvianVisitors/tree/europe-illustrations), 293 species
 - **Germany**: [bassrelic's fork](https://github.com/bassrelic/AvianVisitors-German-Fork/tree/add_german_species), 37 species
+- **The Iberian Peninsula**: [RoqueAlonso's fork](https://github.com/RoqueAlonso/AvianVisitors/tree/iberia-illustrations), 440 species. Work in progress: covers Madrid and Castilla-La Mancha (ES-MD, ES-CM) in full, with partial coverage elsewhere in the Peninsula.
 
 ## South America
 


### PR DESCRIPTION
Adds my Iberian set to the Europe section. Covers Madrid and Castilla-La Mancha in full for now, with partial coverage elsewhere in the Peninsula, and I'll keep extending it.

Branch: https://github.com/RoqueAlonso/AvianVisitors/tree/iberia-illustrations