### PR TITLE
frame: make the mat opening size configurable

### DIFF
--- a/frame/README.md
+++ b/frame/README.md
@@ -4,6 +4,8 @@
 
 A [Pimoroni Inky Impression 13.3"](https://amzn.to/4xlAWr3) (Spectra 6) mirroring the live collage. A Pi screenshots the site, mats it onto an A5 opening, and pushes to the panel, refreshing only when the birds change. Build one of your own at [theodore.net/projects/AvianVisitors#frame-ous](https://theodore.net/projects/AvianVisitors/#frame-ous).
 
+The default layout matches the A5 opening in the frame listed above. If you use a different mat or a bare panel, set `opening` in `~/.birdframe/config.toml`; `0.7071` preserves the current A5 dimensions, while values up to about `0.98` use more of the panel.
+
 ![](https://theodore.net/assets/images/AvianVisitors/final.jpg)
 
 ---

--- a/frame/config.example.toml
+++ b/frame/config.example.toml
@@ -38,6 +38,7 @@ shoot_subtitle = "Heard Today"
 rotate = 90            # 90 or 270 if the frame hangs the other way up
 saturation = 0.6       # Inky colour saturation, 0 to 1
 mat = 0.0              # extra shrink of the content inside the A5 opening (0 = none)
+opening = 0.7071       # fraction of panel height the opening covers; 0.7071 = A5 matboard (default). Raise toward ~0.96-0.98 if you have no matboard and want to fill the bare panel.
 # panel = "el133uf1"   # force the 13.3" driver if auto-detect ever fails
 
 # --- Refresh cadence --------------------------------------------------------

--- a/frame/display.py
+++ b/frame/display.py
@@ -138,6 +138,14 @@ def _paper(img):
 # of the panel that rectangle covers -- 0.7071 reproduces an A5 matboard
 # opening (default), raise it toward ~0.96 to fill a bare panel.
 def opening_size(opening):
+    if isinstance(opening, bool):
+        raise ValueError("opening must be greater than 0 and at most 1")
+    try:
+        opening = float(opening)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("opening must be greater than 0 and at most 1") from exc
+    if not 0 < opening <= 1:
+        raise ValueError("opening must be greater than 0 and at most 1")
     h = PANEL_H * opening
     w = h / 1.41421
     return w, h

--- a/frame/display.py
+++ b/frame/display.py
@@ -53,6 +53,7 @@ DEFAULTS = {
     "shoot_headline_px": 42, "shoot_eyebrow_px": 18, "shoot_lowercase": False,
     "shoot_mat": 0.04, "shoot_small_floor": 0.04, "shoot_count_exp": 0.65,
     "mat": 0.0,             # extra global shrink of the content inside the A5 opening
+    "opening": 0.7071,      # fraction of panel height the opening covers; 0.7071 = A5 matboard (default). Raise toward ~0.96 to fill a bare panel with no matboard.
     "rotate": 90,           # 90 or 270 if the frame hangs the other way up
     "saturation": 0.6,
     "panel": "",            # "el133uf1" forces the 13.3" driver if auto() fails
@@ -132,14 +133,19 @@ def _paper(img):
     return tuple(int(statistics.median(c)) for c in zip(*px))
 
 
-# The mat opening is an A5 rectangle (1 : sqrt(2)) centred in the panel; the
-# content floats inside it with `mat` of inner whitespace.
-A5_H = PANEL_H * 0.7071           # A5 is 1/sqrt(2) of the panel height
-A5_W = A5_H / 1.41421             # A5 aspect 1 : sqrt(2)
+# The opening is a 1:sqrt(2) rectangle centred in the panel; the content
+# floats inside it with `mat` of inner whitespace. `opening` sets how much
+# of the panel that rectangle covers -- 0.7071 reproduces an A5 matboard
+# opening (default), raise it toward ~0.96 to fill a bare panel.
+def opening_size(opening):
+    h = PANEL_H * opening
+    w = h / 1.41421
+    return w, h
 
 
-def _place(content, paper, mat):
-    s = min(A5_W * (1 - mat) / content.width, A5_H * (1 - mat) / content.height)
+def _place(content, paper, mat, opening):
+    box_w, box_h = opening_size(opening)
+    s = min(box_w * (1 - mat) / content.width, box_h * (1 - mat) / content.height)
     nw, nh = max(1, round(content.width * s)), max(1, round(content.height * s))
     content = content.resize((nw, nh), Image.LANCZOS)
     canvas = Image.new("RGB", (PANEL_W, PANEL_H), paper)
@@ -178,8 +184,8 @@ def _centroid_x(img, paper):
 TITLE_H_FRAC, COLLAGE_FRAC, GAP_FRAC = 0.065, 0.66, 0.1
 
 
-def mat_and_center(img, mat):
-    """Crop the title and collage, size each to a fraction of the A5 opening,
+def mat_and_center(img, mat, opening):
+    """Crop the title and collage, size each to a fraction of the opening,
     stack with a gap, and centre on the panel."""
     img = img.convert("RGB")
     paper = _paper(img)
@@ -204,9 +210,10 @@ def mat_and_center(img, mat):
             run = 0
     tb = _region_bbox(img, paper, top, split[0]) if split else None
     cb = _region_bbox(img, paper, split[1], bot + 1) if split else None
-    box_w, box_h = A5_W * (1 - mat), A5_H * (1 - mat)
+    ow, oh = opening_size(opening)
+    box_w, box_h = ow * (1 - mat), oh * (1 - mat)
     if not (tb and cb):
-        return _place(img.crop(full), paper, mat)
+        return _place(img.crop(full), paper, mat, opening)
     title = _scale_h(img.crop(tb), box_h * TITLE_H_FRAC)
     gap = round(box_h * GAP_FRAC)
     # Size the collage to fill the room left under the fixed-size title,
@@ -243,9 +250,10 @@ def quantize_spectra6(img):
     return img.convert("RGB").quantize(palette=pal, dither=Image.Dither.FLOYDSTEINBERG).convert("RGB")
 
 
-def _draw_mat_box(img):
-    """Dev aid: outline the A5 mat opening so the matte and centring show."""
-    x0, y0 = round((PANEL_W - A5_W) / 2), round((PANEL_H - A5_H) / 2)
+def _draw_mat_box(img, opening):
+    """Dev aid: outline the mat opening so the matte and centring show."""
+    ow, oh = opening_size(opening)
+    x0, y0 = round((PANEL_W - ow) / 2), round((PANEL_H - oh) / 2)
     ImageDraw.Draw(img).rectangle((x0, y0, PANEL_W - x0 - 1, PANEL_H - y0 - 1),
                                   outline=(170, 60, 56), width=2)
 
@@ -352,11 +360,11 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
     except Exception as e:
         print(f"could not get image: {e}", file=sys.stderr)  # keep last panel image
         return
-    img = mat_and_center(img, cfg["mat"])
+    img = mat_and_center(img, cfg["mat"], cfg["opening"])
     if preview:
         out = quantize_spectra6(img)
         if mat_box:
-            _draw_mat_box(out)
+            _draw_mat_box(out, cfg["opening"])
         out.save(preview)
         print(f"wrote preview {preview}")
         return


### PR DESCRIPTION
The mat opening was hardcoded to an A5 matboard ratio (0.7071 of 
panel height). This adds an `opening` config option (default 
0.7071, unchanged behaviour) so people running the frame without 
a physical matboard can fill more of the bare panel — up to ~0.96-0.98 
before content starts touching the panel edges.

Tested on a Pimoroni Inky Impression 13.3" with values 0.7071 
(default, matches prior behaviour) through 0.98.