### PR TITLE
fix: restore AvianVisitors webroot after data reset

### DIFF
--- a/scripts/clear_all_data.sh
+++ b/scripts/clear_all_data.sh
@@ -36,8 +36,14 @@ sudo -u ${USER} ln -fs $my_dir/stats.php ${EXTRACTED}
 sudo -u ${USER} ln -fs $my_dir/todays_detections.php ${EXTRACTED}
 sudo -u ${USER} ln -fs $my_dir/history.php ${EXTRACTED}
 sudo -u ${USER} ln -fs $my_dir/weekly_report.php ${EXTRACTED}
-source "$my_dir/link_webroot.sh"
-link_avian_visitors_webroot "$(dirname "$my_dir")" "${EXTRACTED}" "${USER}"
+if ! source "$my_dir/link_webroot.sh"; then
+  echo "Could not load the AvianVisitors webroot helper" >&2
+  exit 1
+fi
+if ! link_avian_visitors_webroot "$(dirname "$my_dir")" "${EXTRACTED}" "${USER}"; then
+  echo "Could not restore the AvianVisitors webroot" >&2
+  exit 1
+fi
 sudo -u ${USER} ln -fs ${HOME}/phpsysinfo ${EXTRACTED}
 sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/phpsysinfo.ini ${HOME}/phpsysinfo/
 sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/green_bootstrap.css ${HOME}/phpsysinfo/templates/
@@ -54,5 +60,8 @@ echo "Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap" >
 ln -sf $(dirname ${my_dir})/BirdDB.txt ${my_dir}/BirdDB.txt
 chown $USER:$USER ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
 echo "Restarting services"
-"$my_dir/update_caddyfile.sh"
+if ! "$my_dir/update_caddyfile.sh"; then
+  echo "Could not update the Caddy configuration; services were not restarted" >&2
+  exit 1
+fi
 restart_services.sh

--- a/scripts/clear_all_data.sh
+++ b/scripts/clear_all_data.sh
@@ -36,7 +36,8 @@ sudo -u ${USER} ln -fs $my_dir/stats.php ${EXTRACTED}
 sudo -u ${USER} ln -fs $my_dir/todays_detections.php ${EXTRACTED}
 sudo -u ${USER} ln -fs $my_dir/history.php ${EXTRACTED}
 sudo -u ${USER} ln -fs $my_dir/weekly_report.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/homepage/images/favicon.ico ${EXTRACTED}
+source "$my_dir/link_webroot.sh"
+link_avian_visitors_webroot "$(dirname "$my_dir")" "${EXTRACTED}" "${USER}"
 sudo -u ${USER} ln -fs ${HOME}/phpsysinfo ${EXTRACTED}
 sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/phpsysinfo.ini ${HOME}/phpsysinfo/
 sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/green_bootstrap.css ${HOME}/phpsysinfo/templates/
@@ -53,4 +54,5 @@ echo "Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap" >
 ln -sf $(dirname ${my_dir})/BirdDB.txt ${my_dir}/BirdDB.txt
 chown $USER:$USER ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
 echo "Restarting services"
+"$my_dir/update_caddyfile.sh"
 restart_services.sh

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -78,8 +78,14 @@ create_necessary_dirs() {
   sudo -u ${USER} ln -fs $my_dir/scripts/todays_detections.php ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/scripts/history.php ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/weekly_report.php ${EXTRACTED}
-  source "$my_dir/scripts/link_webroot.sh"
-  link_avian_visitors_webroot "$my_dir" "${EXTRACTED}" "${USER}"
+  if ! source "$my_dir/scripts/link_webroot.sh"; then
+    echo "Could not load the AvianVisitors webroot helper" >&2
+    exit 1
+  fi
+  if ! link_avian_visitors_webroot "$my_dir" "${EXTRACTED}" "${USER}"; then
+    echo "Could not create the AvianVisitors webroot links" >&2
+    exit 1
+  fi
   sudo -u ${USER} ln -fs ${HOME}/phpsysinfo ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/templates/phpsysinfo.ini ${HOME}/phpsysinfo/
   sudo -u ${USER} ln -fs $my_dir/templates/green_bootstrap.css ${HOME}/phpsysinfo/templates/

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -69,23 +69,6 @@ create_necessary_dirs() {
   sudo -u ${USER} ln -fs $my_dir/include_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/whitelist_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/homepage/* ${EXTRACTED}
-  # AvianVisitors overlay. The avian/ symlink keeps assets + PHP shims
-  # reachable at /avian/. The five frontend files at the EXTRACTED root
-  # make the collage the default index for http://birdnet.local/ -
-  # the matching try_files override in update_caddyfile.sh teaches
-  # php_fastcgi to prefer index.html over index.php at the root. The
-  # stock BirdNET-Pi UI stays reachable at http://birdnet.local/index.php
-  # for anyone who wants to drop into the legacy admin pages.
-  if [ -d $my_dir/avian ]; then
-    sudo -u ${USER} ln -fs $my_dir/avian ${EXTRACTED}/avian
-    sudo -u ${USER} ln -fs $my_dir/avian/frontend/index.html ${EXTRACTED}/index.html
-    sudo -u ${USER} ln -fs $my_dir/avian/frontend/styles.css ${EXTRACTED}/styles.css
-    sudo -u ${USER} ln -fs $my_dir/avian/frontend/apt.js    ${EXTRACTED}/apt.js
-    sudo -u ${USER} ln -fs $my_dir/avian/frontend/masks.json ${EXTRACTED}/masks.json
-    sudo -u ${USER} ln -fs $my_dir/avian/frontend/dims.json  ${EXTRACTED}/dims.json
-    sudo -u ${USER} ln -fs $my_dir/avian/frontend/nest.webp  ${EXTRACTED}/nest.webp
-    sudo -u ${USER} ln -fs $my_dir/avian/assets/favicon.png  ${EXTRACTED}/favicon.png
-  fi
   sudo -u ${USER} ln -fs $my_dir/model/labels.txt ${my_dir}/scripts
   sudo -u ${USER} ln -fs $my_dir/scripts ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/scripts/play.php ${EXTRACTED}
@@ -94,15 +77,9 @@ create_necessary_dirs() {
   sudo -u ${USER} ln -fs $my_dir/scripts/stats.php ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/scripts/todays_detections.php ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/scripts/history.php ${EXTRACTED}
-  sudo -u ${USER} ln -fs $my_dir/scripts/weekly_report.php ${EXTRACTED}
-  # favicon.ico -> AvianVisitors PNG when the overlay is present (modern
-  # browsers accept image/png for the .ico path); fall back to the stock
-  # BirdNET-Pi favicon.ico otherwise so plain installs still get an icon.
-  if [ -d $my_dir/avian ]; then
-    sudo -u ${USER} ln -fs $my_dir/avian/assets/favicon.png ${EXTRACTED}/favicon.ico
-  else
-    sudo -u ${USER} ln -fs $my_dir/homepage/images/favicon.ico ${EXTRACTED}
-  fi
+  sudo -u ${USER} ln -fs $my_dir/weekly_report.php ${EXTRACTED}
+  source "$my_dir/scripts/link_webroot.sh"
+  link_avian_visitors_webroot "$my_dir" "${EXTRACTED}" "${USER}"
   sudo -u ${USER} ln -fs ${HOME}/phpsysinfo ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/templates/phpsysinfo.ini ${HOME}/phpsysinfo/
   sudo -u ${USER} ln -fs $my_dir/templates/green_bootstrap.css ${HOME}/phpsysinfo/templates/

--- a/scripts/link_webroot.sh
+++ b/scripts/link_webroot.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Shared web-root link helper for BirdNET-Pi plus AvianVisitors installs.
+#
+# The BirdNET-Pi installer and clear_all_data.sh both recreate links in
+# ${EXTRACTED}. Keep the AvianVisitors overlay links here so the two paths do
+# not drift: / should serve avian/frontend/index.html, while the stock UI stays
+# available at /index.php.
+
+link_avian_visitors_webroot() {
+  local repo_dir="${1:?repo_dir required}"
+  local web_root="${2:?web_root required}"
+  local run_user="${3:?run_user required}"
+
+  if [ -d "${repo_dir}/avian" ]; then
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian"                    "${web_root}/avian"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/index.html" "${web_root}/index.html"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/styles.css" "${web_root}/styles.css"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/apt.js"     "${web_root}/apt.js"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/masks.json" "${web_root}/masks.json"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/dims.json"  "${web_root}/dims.json"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/nest.webp"  "${web_root}/nest.webp"
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/assets/favicon.png"  "${web_root}/favicon.png"
+    # favicon.ico -> AvianVisitors PNG when the overlay is present (modern
+    # browsers accept image/png for the .ico path); fall back to the stock
+    # BirdNET-Pi favicon.ico otherwise so plain installs still get an icon.
+    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/assets/favicon.png"  "${web_root}/favicon.ico"
+  else
+    sudo -u "${run_user}" ln -fs "${repo_dir}/homepage/images/favicon.ico" "${web_root}"
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  source /etc/birdnet/birdnet.conf
+  link_avian_visitors_webroot "/home/${BIRDNET_USER}/BirdNET-Pi" "${EXTRACTED}" "${BIRDNET_USER}"
+fi

--- a/scripts/link_webroot.sh
+++ b/scripts/link_webroot.sh
@@ -6,26 +6,42 @@
 # not drift: / should serve avian/frontend/index.html, while the stock UI stays
 # available at /index.php.
 
+_avian_link_one() {
+  local run_user="${1:?run_user required}"
+  local source_path="${2:?source_path required}"
+  local target_path="${3:?target_path required}"
+
+  if [ ! -e "${source_path}" ]; then
+    echo "Missing webroot source: ${source_path}" >&2
+    return 1
+  fi
+  if [ -d "${target_path}" ] && [ ! -L "${target_path}" ]; then
+    echo "Refusing to replace directory: ${target_path}" >&2
+    return 1
+  fi
+  sudo -u "${run_user}" ln -sfn "${source_path}" "${target_path}"
+}
+
 link_avian_visitors_webroot() {
   local repo_dir="${1:?repo_dir required}"
   local web_root="${2:?web_root required}"
   local run_user="${3:?run_user required}"
 
   if [ -d "${repo_dir}/avian" ]; then
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian"                    "${web_root}/avian"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/index.html" "${web_root}/index.html"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/styles.css" "${web_root}/styles.css"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/apt.js"     "${web_root}/apt.js"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/masks.json" "${web_root}/masks.json"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/dims.json"  "${web_root}/dims.json"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/frontend/nest.webp"  "${web_root}/nest.webp"
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/assets/favicon.png"  "${web_root}/favicon.png"
+    _avian_link_one "${run_user}" "${repo_dir}/avian"                     "${web_root}/avian" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/frontend/index.html" "${web_root}/index.html" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/frontend/styles.css" "${web_root}/styles.css" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/frontend/apt.js"     "${web_root}/apt.js" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/frontend/masks.json" "${web_root}/masks.json" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/frontend/dims.json"  "${web_root}/dims.json" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/frontend/nest.webp"  "${web_root}/nest.webp" || return 1
+    _avian_link_one "${run_user}" "${repo_dir}/avian/assets/favicon.png"  "${web_root}/favicon.png" || return 1
     # favicon.ico -> AvianVisitors PNG when the overlay is present (modern
     # browsers accept image/png for the .ico path); fall back to the stock
     # BirdNET-Pi favicon.ico otherwise so plain installs still get an icon.
-    sudo -u "${run_user}" ln -fs "${repo_dir}/avian/assets/favicon.png"  "${web_root}/favicon.ico"
+    _avian_link_one "${run_user}" "${repo_dir}/avian/assets/favicon.png" "${web_root}/favicon.ico" || return 1
   else
-    sudo -u "${run_user}" ln -fs "${repo_dir}/homepage/images/favicon.ico" "${web_root}"
+    _avian_link_one "${run_user}" "${repo_dir}/homepage/images/favicon.ico" "${web_root}/favicon.ico" || return 1
   fi
 }
 


### PR DESCRIPTION
Extracts a general web-root link helper shared by install_services.sh and clear_all_data.sh