### PR TITLE
Fix daily_plot.py memory leak in chart_viewer.service

### DIFF
--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -1,10 +1,13 @@
 import argparse
+import gc
 import os
 import sqlite3
 import textwrap
 from datetime import datetime
 from time import sleep
 
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.font_manager as font_manager
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,6 +26,7 @@ def get_data(now=None):
         now = datetime.now()
     df = pd.read_sql_query(f"SELECT * from detections WHERE Date = DATE('{now.strftime('%Y-%m-%d')}')",
                            conn)
+    conn.close()
 
     # Convert Date and Time Fields to Panda's format
     df['Date'] = pd.to_datetime(df['Date'])
@@ -181,7 +185,8 @@ def create_plot(df_plt_today, now, is_top=None):
     save_name = os.path.expanduser(f"~/BirdSongs/Extracted/Charts/{name}-{now.strftime('%Y-%m-%d')}.png")
     plt.savefig(save_name)
     plt.show()
-    plt.close()
+    plt.close(f)
+    gc.collect()
 
 
 def load_fonts():


### PR DESCRIPTION
Noticed system memory climbing steadily on a Pi 4B (2GB), traced it to daily_plot.py growing much faster than birdnet_analysis.py: ~23-25MB/hour vs ~9MB/hour, measured via ps aux RSS samples spaced by the process's accumulated CPU time (ps aux TIME column) rather than wall-clock guesses.

Two issues in the daemon loop (runs every 2 minutes by default):

- get_data() opened a sqlite3 connection per call and never closed it, relying on GC instead of deterministic cleanup.
- create_plot() called bare plt.close() (closes "the current figure") instead of plt.close(f) (the figure just created). matplotlib Figure/Axes/Artist objects hold internal reference cycles that plain refcounting can't free - only a full gc cycle breaks them, and plt.close(f) alone doesn't force that cycle. Added an explicit gc.collect() right after, plus matplotlib.use('Agg') for a deterministic headless backend.

Verified on-device: restarted chart_viewer.service and let it run untouched for ~14h45m (same PID throughout, no crashes). RSS grew 210396KB -> 216872KB, ~0.4MB/hour - a >98% reduction from the original leak rate, effectively flat.