### PR TITLE
fix: honor the "hours" config for the e-ink frame's shoot render

### DIFF
--- a/frame/display.py
+++ b/frame/display.py
@@ -333,7 +333,7 @@ def obtain_image(cfg, species=None):
               headline_px=cfg["shoot_headline_px"], eyebrow_px=cfg["shoot_eyebrow_px"],
               lowercase=cfg["shoot_lowercase"], mat=cfg["shoot_mat"],
               small_floor=cfg["shoot_small_floor"], count_exp=cfg["shoot_count_exp"], timeout_ms=cfg["timeout"] * 1000,
-              user=cfg["basic_user"], password=cfg["basic_pass"])
+              user=cfg["basic_user"], password=cfg["basic_pass"], window_hours=cfg["hours"])
         return Image.open(out).convert("RGB")
     src = cfg["image_url"] or cfg["image"]
     if not src:


### PR DESCRIPTION
obtain_image() read cfg["hours"] only to build the change-detection signature (fetch_species -> fetch_recent), never to render the collage itself. The shoot() call for shoot=true (mic/local mode) had no window_hours, so it always mirrored whatever window the live site defaulted to (24H, since a fresh Playwright context has no bird:window in localStorage) regardless of what "hours" was set to in config.toml. shoot()/shoot.py already supported window_hours (rewrites the page's own action=recent request); it just wasn't wired up here.