### PR TITLE
frame: let the mic Pi render and publish frame.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,13 @@ Everything outside `avian/` and `frame/` is upstream BirdNET-Pi.
 
 ## Wall frame
 
-An optional e-ink frame mirrors the last 24h of birds onto a panel by your window. Build it from [`frame/`](frame/README.md). It can run off your own BirdNET mic, or standalone from BirdWeather data for any ZIP code with no mic at all.
+An optional e-ink frame mirrors the last 24h of birds onto a panel by your window. Build it from [`frame/`](frame/README.md). It can run off your own BirdNET mic, or standalone from BirdWeather data for any ZIP code with no mic at all — or the mic Pi can render and publish the image itself, so the frame Pi needs no browser.
+
+For that last one, run [`frame/install-publish.sh`](frame/install-publish.sh) on the mic Pi whenever you like, or opt in at install time. Note the env var has to go inside `bash -c`, or it applies to `curl` and is silently lost:
+
+```bash
+FRAME_PUBLISH=15min bash -c "$(curl -s https://raw.githubusercontent.com/Twarner491/AvianVisitors/avian-visitors/newinstaller.sh)"
+```
 
 ---
 

--- a/frame/README.md
+++ b/frame/README.md
@@ -78,6 +78,44 @@ birdframe-names off
 
 For an `--image-url` frame, the command adds `labels=1` or `labels=0` to the source URL. The source must honor that setting; otherwise its image will not change.
 
+### Let the mic Pi render (publish mode)
+
+Shooting the collage takes 70–120s and ~1GB of Chromium on a Zero 2 W. If your BirdNET mic is a Pi 4 or 5, let *it* render instead and have the frame just download the finished PNG.
+
+On the **mic Pi**:
+
+```bash
+cd ~/BirdNET-Pi/frame
+./install-publish.sh                     # every 5 min
+./install-publish.sh --interval 15min    # easier on a Pi 3 or a busy box
+```
+
+It installs Playwright, publishes to `/frame.png` on the site Caddy already serves, and prints the URL to use next. No SPI, no panel driver, no reboot. You can also opt in during a fresh BirdNET-Pi install — inside `bash -c`, so the variable reaches the installer rather than `curl`:
+
+```bash
+FRAME_PUBLISH=15min bash -c "$(curl -s https://raw.githubusercontent.com/Twarner491/AvianVisitors/avian-visitors/newinstaller.sh)"
+```
+
+`FRAME_PUBLISH` takes an interval (`5min`, `1h`); `1`, `yes` or `true` mean "just use the default".
+
+A tick that finds no new birds costs ~0.3s on a Pi 5 and never starts a browser; a full render is ~1.8s. The interval is a freshness knob, not a cost one — worst-case bird-to-panel latency is this interval plus the frame Pi's own 15-minute poll.
+
+Then on the **frame Pi**, point the normal installer at that URL:
+
+```bash
+./install.sh --image-url http://<mic-pi>/frame.png
+```
+
+Any URL the frame Pi can resolve works — a LAN address, a [Tailscale](https://tailscale.com) MagicDNS name, a Cloudflare Tunnel hostname (see [`avian/forwarding/`](../avian/forwarding/)). If both Pis are on a tailnet, `tailscale serve --bg 80` on the mic Pi publishes it at `https://<node>.<tailnet>.ts.net/frame.png` with a real certificate and no port forwarding; `install-publish.sh` detects that and prints the tailnet URL for you.
+
+Only the mic Pi decides when to re-render, so `frame.png` changes only when the birds do. The frame Pi asks for it conditionally and skips the panel refresh entirely when the image hasn't changed — no second guess at the same question on a second clock.
+
+Retune titles in `/etc/birdframe/publish.env` and run `sudo systemctl start birdframe-publish`. Keys you add there survive re-runs. If the whole site is behind basic auth, set `FRAME_USER`/`FRAME_PASSWORD` there too — without them the change check gets a 401 every tick, which reads as "nothing new" and freezes the frame on one image.
+
+To remove it: `./install-publish.sh --uninstall` (`scripts/uninstall.sh` discovers units by scanning `install_services.sh`, so it cannot see this one).
+
+**Labels and this source.** `birdframe-names` appends `labels=1` to the image URL, but the publisher serves one pre-rendered PNG and ignores the parameter, so toggling names on a frame pointed at it changes nothing. Set the names on the mic Pi instead, or run the frame in a rendering mode. Publishing a second labelled variant is tracked separately.
+
 BirdWeather mode renders on the Pi from this repo's illustrations on GitHub, so there is no image set to copy over. ZIP codes with no station nearby fall back to the closest ones. If you are far from any BirdWeather station, add `--ebird-key <key>` (a free key from [ebird.org/api/keygen](https://ebird.org/api/keygen)) and the frame fills from eBird sightings instead.
 
 The bundled illustrations center on the western U.S. If birds near your ZIP aren't in the set you cloned, the installer flags them and the frame skips them until they exist. To generate them, run [`generate_illustrations.py`](generate_illustrations.py) on a laptop or workstation (it uses the same rembg cutout as the rest of the pipeline, which the Pi can't fit in memory), passing your ZIP and a paid Google Gemini key, then commit the new cutouts or copy them to the Pi:

--- a/frame/config.example.toml
+++ b/frame/config.example.toml
@@ -11,6 +11,11 @@ shoot = true
 # something that serves a frame image, e.g. a public Cloudflare Worker):
 # shoot = false
 # image_url = "https://bird.onethreenine.net/frame.png?k=YOUR_FRAME_KEY"
+# ...or let the mic Pi render it (run frame/install-publish.sh over there). The
+# panel then refreshes when the downloaded PNG itself changes, so base_url above
+# is written for reference only and is never fetched in this mode:
+# image_url = "http://birdnet.local/frame.png"
+# timeout = 30       # with image_url this only detects a stall, it is not a render budget
 # Or read a PNG a sibling process drops next to us:
 # image = "~/.birdframe/frame.png"
 

--- a/frame/display.py
+++ b/frame/display.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 """Frame-Pi client: turn a collage screenshot into Inky panel pixels.
 
-Runs on the frame Pi (a 3 A+ or Zero 2 W) on a systemd timer. Each run it decides whether a
-refresh is worth it (the species set or call-count brackets changed, and it
-is not quiet hours), then crops the title and collage from the screenshot,
-centres and mats them, and pushes the result to the Inky Impression 13.3".
-``--preview out.png`` writes an approximate 6-ink dither instead, so the
+Runs on the frame Pi (a 3 A+ or Zero 2 W) on a systemd timer. Each run it decides
+whether a refresh is worth it, then crops the title and collage from the
+screenshot, centres and mats them, and pushes the result to the Inky Impression
+13.3". ``--preview out.png`` writes an approximate 6-ink dither instead, so the
 look can be checked on any machine without the panel.
+
+How "worth it" is decided depends on where the image comes from. When this Pi
+renders (local or birdweather mode) it hashes the species set and call-count
+brackets. When the mic Pi publishes a PNG for us (image_url mode) the published
+bytes are the signal instead: a conditional GET, and a 304 means nothing to do.
+Re-deriving the answer from the API there would be a second gate on a second
+clock, which can fire on a bird the downloaded image predates. Either way a
+refresh is suppressed during quiet hours.
 """
 from __future__ import annotations
 
@@ -22,6 +29,7 @@ import re
 import statistics
 import sys
 import time
+import urllib.error   # explicit: urllib.request happens to pull it in, but the 304 path relies on it
 import urllib.request
 from datetime import datetime
 
@@ -111,13 +119,58 @@ def fetch_species(cfg, auth=None):
 
 
 # --- image ------------------------------------------------------------------
+NOT_MODIFIED = object()   # sentinel: the server says the bytes have not changed
+
+
+def _http_image(url, timeout, auth=None, validators=None):
+    """Download the frame, optionally conditionally.
+
+    `validators` is the {"etag", "last_modified"} recorded from the previous
+    fetch; when given, this sends a conditional request and returns
+    NOT_MODIFIED instead of a body if the server answers 304. Returns
+    (Image | NOT_MODIFIED, validators from this response).
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": "AvianVisitors-frame/1.0"})
+    if auth:
+        req.add_header("Authorization", auth)
+    if validators:
+        if validators.get("etag"):
+            req.add_header("If-None-Match", validators["etag"])
+        if validators.get("last_modified"):
+            req.add_header("If-Modified-Since", validators["last_modified"])
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            body = r.read(20_000_000)
+            ctype = (r.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            # Only real values: a dict of two Nones is still truthy, so keeping
+            # them would make the next run take the conditional branch, send no
+            # conditional headers, and get a 200 every time - a gate that has
+            # silently turned itself off while logging "refresh: changed"
+            # forever. Empty means "cannot gate", and says so below.
+            got = {k: v for k, v in (("etag", r.headers.get("ETag")),
+                                     ("last_modified", r.headers.get("Last-Modified"))) if v}
+    except urllib.error.HTTPError as e:
+        if e.code == 304:
+            return NOT_MODIFIED, validators
+        raise
+    # A missing frame.png does NOT 404 on a BirdNET-Pi: Caddy's try_files falls
+    # through to index.php, so an unpublished frame - or a dangling symlink -
+    # comes back as 200 with the HTML shell. Match on markup rather than on
+    # "not image/*", because some object stores and workers serve a perfectly
+    # good PNG as application/octet-stream.
+    if ctype.startswith("text/") or ctype.endswith(("html", "xml", "json")):
+        raise RuntimeError(
+            f"{url} returned {ctype}, not an image - is the publisher running?")
+    if not got:
+        print(f"{url} sends no ETag or Last-Modified; refreshing every run",
+              file=sys.stderr)
+    return Image.open(io.BytesIO(body)).convert("RGB"), got
+
+
 def get_image(src, timeout, auth=None):
     if re.match(r"^https?://", src):
-        req = urllib.request.Request(src, headers={"User-Agent": "AvianVisitors-frame/1.0"})
-        if auth:
-            req.add_header("Authorization", auth)
-        with urllib.request.urlopen(req, timeout=timeout) as r:
-            return Image.open(io.BytesIO(r.read(20_000_000))).convert("RGB")
+        img, _ = _http_image(src, timeout, auth)
+        return img
     return Image.open(os.path.expanduser(src)).convert("RGB")
 
 
@@ -294,12 +347,15 @@ def load_state(path):
         return {"signature": None, "last_refresh": 0}
 
 
-def save_state(path, sig, when):
+def save_state(path, sig, when, validators=None):
+    """`validators` is image mode's {etag, last_modified}; keeping it here is
+    what lets the next run send a conditional request. Optional so publish.py
+    and the other three modes can keep calling this with three arguments."""
     path = os.path.expanduser(path)
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
-        json.dump({"signature": sig, "last_refresh": when}, f)
+        json.dump({"signature": sig, "last_refresh": when, "validators": validators}, f)
         f.flush()
         os.fsync(f.fileno())
     os.replace(tmp, path)  # atomic: a power cut can't leave a half-written file
@@ -361,25 +417,60 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
     state = load_state(cfg["state"])
     sig = None
     species = None
-    if use_signature:
-        try:
-            species = fetch_species(cfg, _auth(cfg))
-            sig = signature(species)
-        except Exception as e:
-            print(f"signature fetch failed: {e}", file=sys.stderr)  # treat as no change
+    fetched = None                        # image mode downloads during its gate
+    validators = state.get("validators")
     heal_due = now - state.get("last_refresh", 0) >= cfg["heal_hours"] * 3600
-    changed = (not use_signature) or (sig is not None and sig != state.get("signature"))
-    if not force and not preview:
-        if in_quiet_hours(cfg, datetime.now().hour):
-            print("quiet hours; skip")
+
+    # In image mode the published PNG *is* the signal. The mic Pi's publisher
+    # only re-renders when the birds change, so unchanged bytes mean there is
+    # nothing new to draw. Asking the API here instead would be a second gate on
+    # a second clock: it can flip on a bird the downloaded image predates, which
+    # strands a stale collage on the panel until the next species change or the
+    # daily heal, with both machines logging success. It also drops this mode's
+    # dependence on base_url being reachable at all.
+    gate_on_image = (use_signature and bool(cfg["image_url"]) and not cfg["shoot"]
+                     and cfg.get("species_source") != "birdweather")
+
+    if not force and not preview and in_quiet_hours(cfg, datetime.now().hour):
+        print("quiet hours; skip")
+        return
+
+    if gate_on_image:
+        # Send the validators only when a 304 would actually let us stop. On a
+        # heal we want the bytes back even though nothing changed, so the panel
+        # redraws and clears its ghosting.
+        conditional = None if (force or preview or heal_due) else validators
+        try:
+            fetched, got = _http_image(cfg["image_url"], cfg["timeout"], _auth(cfg), conditional)
+        except Exception as e:
+            print(f"could not get image: {e}", file=sys.stderr)  # keep last panel image
             return
-        if not changed and not heal_due:
+        if fetched is NOT_MODIFIED:
             print("no change; skip")
             return
-        print("refresh:", "changed" if changed else "heal")
+        # `got`, not `got or validators`: we just downloaded new bytes, so the
+        # old validators describe an image that is no longer the one on the
+        # panel. Keeping them would send a stale If-None-Match and could take a
+        # 304 for the wrong image.
+        validators = got or None
+        if not force and not preview:
+            print("refresh:", "heal" if heal_due else "changed")
+    else:
+        if use_signature:
+            try:
+                species = fetch_species(cfg, _auth(cfg))
+                sig = signature(species)
+            except Exception as e:
+                print(f"signature fetch failed: {e}", file=sys.stderr)  # treat as no change
+        changed = (not use_signature) or (sig is not None and sig != state.get("signature"))
+        if not force and not preview:
+            if not changed and not heal_due:
+                print("no change; skip")
+                return
+            print("refresh:", "changed" if changed else "heal")
 
     try:
-        img = fit_panel(obtain_image(cfg, species))
+        img = fit_panel(fetched if fetched is not None else obtain_image(cfg, species))
     except Exception as e:
         print(f"could not get image: {e}", file=sys.stderr)  # keep last panel image
         return
@@ -396,7 +487,7 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
     except Exception as e:
         print(f"panel push failed: {e}", file=sys.stderr)
         return
-    save_state(cfg["state"], sig if sig is not None else state.get("signature"), now)
+    save_state(cfg["state"], sig if sig is not None else state.get("signature"), now, validators)
     print("panel updated")
 
 

--- a/frame/display.py
+++ b/frame/display.py
@@ -347,15 +347,17 @@ def load_state(path):
         return {"signature": None, "last_refresh": 0}
 
 
-def save_state(path, sig, when, validators=None):
-    """`validators` is image mode's {etag, last_modified}; keeping it here is
-    what lets the next run send a conditional request. Optional so publish.py
-    and the other three modes can keep calling this with three arguments."""
+def save_state(path, sig, when, validators=None, url=None):
+    """`validators` is image mode's {etag, last_modified} and `url` is the
+    address they describe; keeping both is what lets the next run send a
+    conditional request and know when it must not. Optional so publish.py and
+    the other three modes can keep calling this with three arguments."""
     path = os.path.expanduser(path)
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
-        json.dump({"signature": sig, "last_refresh": when, "validators": validators}, f)
+        json.dump({"signature": sig, "last_refresh": when,
+                   "validators": validators, "url": url}, f)
         f.flush()
         os.fsync(f.fileno())
     os.replace(tmp, path)  # atomic: a power cut can't leave a half-written file
@@ -418,6 +420,7 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
     sig = None
     species = None
     fetched = None                        # image mode downloads during its gate
+    resolved_url = state.get("url")       # the URL those validators describe
     validators = state.get("validators")
     heal_due = now - state.get("last_refresh", 0) >= cfg["heal_hours"] * 3600
 
@@ -436,12 +439,23 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
         return
 
     if gate_on_image:
+        # Ask the source for names the same way obtain_image does. The gate path
+        # bypasses obtain_image entirely, so without this the label preference
+        # would silently never reach an image_url source.
+        src = frame_url(cfg["image_url"], cfg["bird_names"])
+        # A validator only means anything for the URL it came from. Toggling
+        # labels changes the URL but not the file caddy serves, so the ETag is
+        # unchanged and a stale validator would take a 304 for an image rendered
+        # under the other setting. State written before this key existed has no
+        # url, which has to mean "drop them once", not "assume they match".
+        if state.get("url") != src:
+            validators = None
         # Send the validators only when a 304 would actually let us stop. On a
         # heal we want the bytes back even though nothing changed, so the panel
         # redraws and clears its ghosting.
         conditional = None if (force or preview or heal_due) else validators
         try:
-            fetched, got = _http_image(cfg["image_url"], cfg["timeout"], _auth(cfg), conditional)
+            fetched, got = _http_image(src, cfg["timeout"], _auth(cfg), conditional)
         except Exception as e:
             print(f"could not get image: {e}", file=sys.stderr)  # keep last panel image
             return
@@ -453,6 +467,7 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
         # panel. Keeping them would send a stale If-None-Match and could take a
         # 304 for the wrong image.
         validators = got or None
+        resolved_url = src
         if not force and not preview:
             print("refresh:", "heal" if heal_due else "changed")
     else:
@@ -487,7 +502,8 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
     except Exception as e:
         print(f"panel push failed: {e}", file=sys.stderr)
         return
-    save_state(cfg["state"], sig if sig is not None else state.get("signature"), now, validators)
+    save_state(cfg["state"], sig if sig is not None else state.get("signature"), now,
+               validators, resolved_url)
     print("panel updated")
 
 

--- a/frame/install-publish.sh
+++ b/frame/install-publish.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# Install the frame publisher on the BirdNET *mic* Pi: render frame.png on a
+# timer and serve it from the site Caddy already hosts, so the frame Pi can run
+# in image mode with no browser at all.
+#
+#   ./install-publish.sh                       every 5 min, default titles
+#   ./install-publish.sh --interval 15min      easier on a Pi 3 or a busy box
+#   ./install-publish.sh --title "..." --subtitle "..."
+#   ./install-publish.sh --refresh             re-point after moving the clone
+#   ./install-publish.sh --uninstall           remove everything it installed
+#
+# This is NOT install.sh. It touches no SPI, installs no panel driver, and never
+# reboots. Run install.sh on the frame Pi and this on the mic Pi.
+#
+# Nothing machine-specific goes into the shipped unit files. Three generated
+# pieces carry it: the launcher, a User= drop-in, and /etc/birdframe/publish.env.
+set -euo pipefail
+
+# Resolve before the cd, and through a symlink, so --help and the launcher both
+# get real absolute paths however this was invoked.
+SELF="$(readlink -f "$0")"
+cd "$(dirname "$SELF")"
+FRAME="$(pwd)"
+
+LAUNCHER=/usr/local/bin/birdframe-publish
+ENV_DIR=/etc/birdframe
+ENV_FILE="$ENV_DIR/publish.env"
+UNIT_DIR=/etc/systemd/system
+SERVICE=birdframe-publish.service
+TIMER=birdframe-publish.timer
+MIN_INTERVAL_SEC=60   # see the --interval validation below
+
+INTERVAL=""
+TITLE=""; TITLE_SET=0
+SUBTITLE=""; SUBTITLE_SET=0
+URL=""; URL_SET=0
+OUT=""; OUT_SET=0
+ENABLE=1
+ACTION=install
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --interval) [ $# -ge 2 ] || { echo "--interval needs a value, e.g. --interval 15min" >&2; exit 1; }
+                INTERVAL="$2"; shift 2 ;;
+    --interval=*) INTERVAL="${1#*=}"; shift ;;
+    --title) [ $# -ge 2 ] || { echo "--title needs a value" >&2; exit 1; }
+             TITLE="$2"; TITLE_SET=1; shift 2 ;;
+    --title=*) TITLE="${1#*=}"; TITLE_SET=1; shift ;;
+    --subtitle) [ $# -ge 2 ] || { echo "--subtitle needs a value" >&2; exit 1; }
+                SUBTITLE="$2"; SUBTITLE_SET=1; shift 2 ;;
+    --subtitle=*) SUBTITLE="${1#*=}"; SUBTITLE_SET=1; shift ;;
+    --url) [ $# -ge 2 ] || { echo "--url needs a URL, e.g. --url http://127.0.0.1/" >&2; exit 1; }
+           URL="$2"; URL_SET=1; shift 2 ;;
+    --url=*) URL="${1#*=}"; URL_SET=1; shift ;;
+    --out) [ $# -ge 2 ] || { echo "--out needs a path" >&2; exit 1; }
+           OUT="$2"; OUT_SET=1; shift 2 ;;
+    --out=*) OUT="${1#*=}"; OUT_SET=1; shift ;;
+    --no-enable) ENABLE=0; shift ;;
+    --refresh) ACTION=refresh; shift ;;
+    --uninstall) ACTION=uninstall; shift ;;
+    -h|--help) sed -n '2,16p' "$SELF" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- validation -------------------------------------------------------------
+# Values land in an EnvironmentFile that later runs read back, and in a sed
+# replacement, so the character set is deliberately narrow. Rejecting $, `, \,
+# |, " and newline here is what makes both of those safe; it also rejects a flag
+# accidentally passed as a value (e.g. "--title --subtitle").
+# A function, not inline: the interactive prompt must apply the exact same
+# rules. Validating there with systemd-analyze alone let a bare "5" through, and
+# the prompt is the path a human actually uses.
+check_interval() {
+  local span
+  # Let systemd parse its own time spans rather than guessing at a regex, so
+  # 15min, 900s and 1h all work and a typo fails here instead of at daemon-reload.
+  # The microseconds line is labelled with a mu, which would make a label match
+  # depend on the locale and on UTF-8 surviving the pipe; take the first purely
+  # numeric value instead. Empty means systemd rejected the span.
+  span="$(systemd-analyze timespan "$1" 2>/dev/null \
+          | awk -F': *' 'NR>1 && $2 ~ /^[0-9]+$/ {print $2; exit}' || true)"
+  if [ -z "$span" ]; then
+    echo "'$1' is not a systemd time span; try 15min, 900s or 1h." >&2
+    return 1
+  fi
+  # 'infinity' parses to 2^64-1, which overflows bash's signed comparison and
+  # would slip past the floor below with a raw "integer expression expected".
+  if [ "${#span}" -gt 15 ]; then
+    echo "'$1' is not a usable interval." >&2
+    return 1
+  fi
+  # A bare number is seconds to systemd, so "5" would launch Chromium every five
+  # seconds on a Pi that is also doing realtime tflite inference.
+  if [ "$span" -lt $((MIN_INTERVAL_SEC * 1000000)) ]; then
+    echo "'$1' is under ${MIN_INTERVAL_SEC}s; that renders faster than the frame can use it." >&2
+    echo "Did you mean '${1}min'?" >&2
+    return 1
+  fi
+  return 0
+}
+if [ -n "$INTERVAL" ] && ! check_interval "$INTERVAL"; then
+  exit 1
+fi
+# A newline passes any `grep -qE '^...$'` check, because grep matches per line -
+# so validate it separately. In the append branch of env_set an embedded newline
+# would write a whole extra key.
+for v in "$INTERVAL" "$URL" "$OUT" "$TITLE" "$SUBTITLE"; do
+  case "$v" in
+    *$'\n'*) echo "values cannot contain newlines" >&2; exit 1 ;;
+    --*) echo "'$v' looks like a flag, not a value - did you leave one out?" >&2; exit 1 ;;
+  esac
+done
+if [ "$URL_SET" = 1 ] && ! printf '%s' "$URL" | LC_ALL=C grep -qE '^https?://[A-Za-z0-9._~:/?#@!$&()*+,;=%-]+$'; then
+  echo "--url should be a plain http(s) URL, e.g. http://127.0.0.1/" >&2
+  exit 1
+fi
+if [ "$OUT_SET" = 1 ] && ! printf '%s' "$OUT" | LC_ALL=C grep -qE '^/[A-Za-z0-9._/-]*\.png$'; then
+  echo "--out should be an absolute path ending in .png, with no shell metacharacters" >&2
+  exit 1
+fi
+for v in "$TITLE" "$SUBTITLE"; do
+  if [ -n "$v" ] && ! printf '%s' "$v" | LC_ALL=C grep -qE "^[A-Za-z0-9 .,'!?&()·–-]{1,60}$"; then
+    echo "titles must be plain text, 60 characters or fewer: '$v'" >&2
+    exit 1
+  fi
+done
+
+# --- config file helpers ----------------------------------------------------
+# publish.env is read with grep rather than `source`d. It is a systemd
+# EnvironmentFile, not a shell script: systemd accepts unquoted interior
+# whitespace that bash would try to execute, and sourcing it would also run
+# anything a hand edit introduced.
+env_get() {
+  [ -f "$ENV_FILE" ] || return 0
+  sed -n "s/^${1}=//p" "$ENV_FILE" | tail -n1 | sed -e 's/^"//' -e 's/"$//'
+}
+# Rewrite one key in place, leaving every other key and all comments alone. The
+# whole-file rewrite this replaces silently dropped FRAME_USER/FRAME_PASSWORD on
+# every --refresh, which is exactly the basic-auth freeze publish.py warns about.
+env_set() {
+  # & in a sed replacement means "the whole match", and the title and URL
+  # charsets both allow it (query strings, "Birds & Bees"). Unescaped, that
+  # rewrites FRAME_TITLE="Birds & Bees" as FRAME_TITLE="Birds FRAME_TITLE="Avian
+  # Visitors" Bees" and reports success. Escape it and the delimiter.
+  local esc; esc="$(printf '%s' "$2" | sed 's/[&|\\]/\\&/g')"
+  if sudo grep -qs "^${1}=" "$ENV_FILE"; then
+    sudo sed -i "s|^${1}=.*|${1}=\"${esc}\"|" "$ENV_FILE"
+  else
+    printf '%s="%s"\n' "$1" "$2" | sudo tee -a "$ENV_FILE" >/dev/null
+  fi
+}
+
+# --- uninstall --------------------------------------------------------------
+# uninstall.sh discovers units by awk-ing install_services.sh and cannot see
+# this one, so removal has to live here.
+if [ "$ACTION" = uninstall ]; then
+  sudo systemctl disable --now "$TIMER" 2>/dev/null || true
+  sudo systemctl stop "$SERVICE" 2>/dev/null || true   # disabling the timer does not stop a render in flight
+  STATE_DIR="$(env_get FRAME_STATE)"
+  sudo rm -rf "$UNIT_DIR/$TIMER" "$UNIT_DIR/$SERVICE" \
+              "$UNIT_DIR/$SERVICE.d" "$UNIT_DIR/$TIMER.d" \
+              "$LAUNCHER" "$ENV_DIR"
+  sudo systemctl daemon-reload
+  rm -f "$HOME/.birdframe/publish-state.json" "$HOME/.birdframe/.publish.lock" 2>/dev/null || true
+  [ -n "$STATE_DIR" ] && rm -f "$STATE_DIR" 2>/dev/null || true
+  if [ -f /etc/birdnet/birdnet.conf ]; then
+    # shellcheck disable=SC1091
+    source /etc/birdnet/birdnet.conf
+    if [ -n "${EXTRACTED:-}" ] && [ -L "$EXTRACTED/frame.png" ]; then
+      sudo rm -f "$EXTRACTED/frame.png"
+    fi
+  fi
+  echo "Removed the frame publisher. Rendered frames and $FRAME/.venv were left in place."
+  exit 0
+fi
+
+# --- preflight --------------------------------------------------------------
+# Run as the BirdNET user, not with sudo. Under sudo, \$USER is root: the venv,
+# the Playwright browser cache and every rendered PNG land root-owned in a tree
+# BirdNET-Pi's own scripts expect to own, and User= in the drop-in would be
+# root. The script sudos for the handful of steps that need it.
+if [ "$(id -u)" = 0 ]; then
+  echo "Run this as the BirdNET user, not as root:  ./install-publish.sh" >&2
+  echo "It uses sudo only for the steps that need it." >&2
+  exit 1
+fi
+# install.sh writes this file on the frame Pi. A publisher there would be
+# screenshotting a site that machine does not host.
+if [ -f "$HOME/.birdframe/config.toml" ]; then
+  echo "$HOME/.birdframe/config.toml exists - this looks like the frame Pi." >&2
+  echo "install-publish.sh belongs on the BirdNET mic Pi; run install.sh here instead." >&2
+  exit 1
+fi
+# The publisher screenshots the local site and writes into its web root, so a
+# BirdNET-Pi install must be here. birdnet.conf is also where EXTRACTED and
+# RECS_DIR come from - never hardcode ~/BirdSongs.
+if [ ! -f /etc/birdnet/birdnet.conf ]; then
+  echo "no /etc/birdnet/birdnet.conf - is this the BirdNET mic Pi?" >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source /etc/birdnet/birdnet.conf
+: "${RECS_DIR:?RECS_DIR missing from birdnet.conf}"
+: "${EXTRACTED:?EXTRACTED missing from birdnet.conf}"
+SVC_USER="$(id -un)"
+# The rendered PNG has to be writable by the service user and readable by caddy,
+# which is in the BirdNET user's group. A mismatch fails later with a bare
+# permission error or a silent 403, so catch it here.
+if [ -n "${BIRDNET_USER:-}" ] && [ "$BIRDNET_USER" != "$SVC_USER" ]; then
+  echo "You are '$SVC_USER' but BirdNET runs as '$BIRDNET_USER'." >&2
+  echo "Run this as $BIRDNET_USER, or the frame will not be writable or servable." >&2
+  exit 1
+fi
+FRAME_DIR="$RECS_DIR/frame"
+
+# Resolve the output path only now: an existing install's FRAME_OUT must win
+# over the default, or --refresh would silently move the published frame and
+# orphan whatever the renderer keeps writing.
+if [ "$OUT_SET" = 0 ]; then
+  OUT="$(env_get FRAME_OUT)"
+  [ -n "$OUT" ] || OUT="$FRAME_DIR/frame.png"
+fi
+
+# Interactive only when a human is driving and gave no flags. The main
+# installer's FRAME_PUBLISH path and any CI run are non-interactive and take the
+# defaults silently.
+if [ "$ACTION" = install ] && [ -t 0 ] && [ -z "$INTERVAL" ] \
+   && [ "$TITLE_SET$SUBTITLE_SET$URL_SET$OUT_SET" = "0000" ]; then
+  # `|| true` on every read: EOF (Ctrl-D) returns non-zero and would otherwise
+  # abort the installer under set -e with no message.
+  read -r -p "Re-check for new birds every [15min]: " ans || true
+  # check_interval, not a bare systemd-analyze: the floor has to apply here too,
+  # and this prompt actively invites the bare number that trips it.
+  if [ -n "${ans:-}" ] && check_interval "$ans"; then INTERVAL="$ans"
+  elif [ -n "${ans:-}" ]; then echo "Using the 15min default." >&2; fi
+  read -r -p "Frame title [Avian Visitors]: " ans || true
+  [ -n "${ans:-}" ] && { TITLE="$ans"; TITLE_SET=1; }
+  read -r -p "Frame subtitle [Heard Today]: " ans || true
+  [ -n "${ans:-}" ] && { SUBTITLE="$ans"; SUBTITLE_SET=1; }
+  for v in "$TITLE" "$SUBTITLE"; do
+    if [ -n "$v" ] && ! printf '%s' "$v" | LC_ALL=C grep -qE "^[A-Za-z0-9 .,'!?&()·–-]{1,60}$"; then
+      echo "titles must be plain text, 60 characters or fewer: '$v'" >&2
+      exit 1
+    fi
+  done
+fi
+
+# --- 1/3  venv + Chromium ---------------------------------------------------
+if [ "$ACTION" = install ]; then
+  echo "1/3  Installing Playwright + Chromium (~1GB, several minutes)..."
+  # uv is much faster and produces a bit-for-bit ordinary .venv, so everything
+  # downstream is identical either way. Use it when it is already there; never
+  # install it - requiring `curl | sh` on a Pi is a worse trade than waiting.
+  if command -v uv >/dev/null 2>&1; then
+    uv venv .venv
+    uv pip install --quiet --python .venv/bin/python -r requirements-publish.txt
+  else
+    sudo apt-get update -qq   # a Pi that has been up for months has a stale index
+    sudo apt-get install -y python3-venv   # no build-essential: these are pure wheels
+    python3 -m venv .venv
+    .venv/bin/pip install -q --upgrade pip
+    .venv/bin/pip install -q -r requirements-publish.txt
+  fi
+  sudo .venv/bin/playwright install-deps chromium
+  .venv/bin/playwright install chromium
+else
+  echo "1/3  Refreshing an existing install (skipping Playwright)..."
+  [ -x "$FRAME/.venv/bin/python" ] || { echo "no venv at $FRAME/.venv; run without --refresh" >&2; exit 1; }
+fi
+
+# --- 2/3  the generated, machine-specific pieces -----------------------------
+echo "2/3  Writing the launcher, config and units..."
+mkdir -p "$FRAME_DIR"
+
+# The real PNG lives outside the web root and is symlinked in - the same shape
+# spectrogram.png already uses (scripts/install_services.sh). publish.py
+# os.replace()s the real path; replacing the symlink would turn it into a
+# regular file and orphan the target.
+if [ -d "$EXTRACTED/frame.png" ] && [ ! -L "$EXTRACTED/frame.png" ]; then
+  # ln -sfn into an existing directory succeeds by creating a link *inside* it,
+  # which would leave /frame.png serving a browsable listing forever.
+  echo "$EXTRACTED/frame.png is a directory; move it aside and re-run." >&2
+  exit 1
+fi
+ln -sfn "$OUT" "$EXTRACTED/frame.png"
+
+# The one file that knows where anything lives, so the shipped unit does not.
+sudo tee "$LAUNCHER" >/dev/null <<LAUNCH
+#!/bin/sh
+# Generated by frame/install-publish.sh. The systemd unit calls this instead of
+# an absolute python path, so the shipped unit carries no machine-specific path.
+# Re-run 'install-publish.sh --refresh' if you move the clone.
+
+# Playwright's browser cache is per-user and lives in \$HOME/.cache/ms-playwright.
+# Under sudo that resolves to /root, where nothing is installed, so a hand run as
+# root dies with "Executable doesn't exist at /root/.cache/..." and a misleading
+# "run playwright install" banner - and drops a stray lock in /root/.birdframe.
+# Fail early with the actual answer instead.
+if [ "\$(id -u)" = 0 ]; then
+  echo "birdframe-publish runs as $SVC_USER, not root (Playwright's cache is per-user)." >&2
+  echo "Use:  sudo systemctl start $SERVICE" >&2
+  echo "  or: sudo -u $SVC_USER $LAUNCHER \$*" >&2
+  exit 1
+fi
+exec "$FRAME/.venv/bin/python" "$FRAME/publish.py" "\$@"
+LAUNCH
+sudo chmod 755 "$LAUNCHER"
+
+# Config the user is expected to edit. Created once with the full set of
+# defaults; after that only the keys actually passed are rewritten, so hand-added
+# keys, comments and credentials survive every upgrade and --refresh.
+sudo mkdir -p "$ENV_DIR"
+if [ ! -f "$ENV_FILE" ]; then
+  sudo tee "$ENV_FILE" >/dev/null <<ENV
+# Frame publisher settings. Edit, then:  sudo systemctl start $SERVICE
+# Every key matches a publish.py flag; run '$LAUNCHER --help' for the full list.
+# Keys you add here are preserved when install-publish.sh is re-run.
+FRAME_URL="http://127.0.0.1/"
+FRAME_OUT="$OUT"
+FRAME_TITLE="Avian Visitors"
+FRAME_SUBTITLE="Heard Today"
+# If the whole site is behind basic auth, set these too - without them the
+# change-detection fetch 401s every tick and the frame freezes on one image:
+# FRAME_USER="..."
+# FRAME_PASSWORD="..."
+ENV
+fi
+[ "$URL_SET" = 1 ] && env_set FRAME_URL "$URL"
+[ "$OUT_SET" = 1 ] && env_set FRAME_OUT "$OUT"
+[ "$TITLE_SET" = 1 ] && env_set FRAME_TITLE "$TITLE"
+[ "$SUBTITLE_SET" = 1 ] && env_set FRAME_SUBTITLE "$SUBTITLE"
+# --refresh exists to re-point after a clone move; the launcher above is what
+# actually moved, and FRAME_OUT is re-asserted in case the tree was relocated.
+[ "$ACTION" = refresh ] && env_set FRAME_OUT "$OUT"
+
+# Units go in unmodified; only the drop-ins are generated.
+sudo cp "$FRAME/systemd/$SERVICE" "$UNIT_DIR/$SERVICE"
+sudo cp "$FRAME/systemd/$TIMER" "$UNIT_DIR/$TIMER"
+sudo mkdir -p "$UNIT_DIR/$SERVICE.d"
+sudo tee "$UNIT_DIR/$SERVICE.d/10-local.conf" >/dev/null <<DROPIN
+# Generated by frame/install-publish.sh. User= cannot come from an
+# EnvironmentFile, so it is the one [Service] key that has to be a drop-in.
+[Service]
+User=$SVC_USER
+DROPIN
+if [ -n "$INTERVAL" ]; then
+  sudo mkdir -p "$UNIT_DIR/$TIMER.d"
+  sudo tee "$UNIT_DIR/$TIMER.d/10-schedule.conf" >/dev/null <<DROPIN
+# Generated by frame/install-publish.sh --interval. OnUnitActiveSec= is not
+# env-expandable, so the schedule is a drop-in rather than an edit to the timer.
+#
+# The bare assignment first is load-bearing: these are LIST-valued settings, so
+# a plain OnUnitActiveSec= in a drop-in APPENDS a second trigger instead of
+# replacing the shipped 15min one. Without the reset, a longer interval would
+# silently do nothing (15min still elapses first) while the installer claimed
+# otherwise. The reset also clears OnBootSec=, so it is restated here.
+[Timer]
+OnUnitActiveSec=
+OnBootSec=3min
+OnUnitActiveSec=$INTERVAL
+DROPIN
+elif [ "$ACTION" != refresh ]; then
+  # Drop only our own file, never the whole .d directory: `systemctl edit
+  # birdframe-publish.timer` writes override.conf in there, and the shipped unit
+  # tells people to do exactly that. And never on --refresh - an update runs
+  # that, and it must not silently reset a schedule the user chose.
+  sudo rm -f "$UNIT_DIR/$TIMER.d/10-schedule.conf"
+fi
+sudo systemctl daemon-reload
+# enable without --now, and start the timer only after the checks below: with
+# OnBootSec=3min always in the past on a running machine, activating the timer
+# fires a run immediately, which would race the controlled first render.
+# Not on --refresh either: an update must not re-enable a timer someone stopped.
+[ "$ENABLE" = 1 ] && [ "$ACTION" != refresh ] && sudo systemctl enable "$TIMER" >/dev/null
+
+# --- 3/3  prove it ----------------------------------------------------------
+echo "3/3  Rendering the first frame..."
+BEFORE="$(stat -c %Y "$OUT" 2>/dev/null || echo 0)"
+# --force, and through the launcher rather than the unit. A plain service start
+# exits 0 on "no change; skip", so on a re-install over existing state the
+# installer would report success without this run having rendered anything -
+# and the PNG check below would happily pass against a stale file. Forcing makes
+# the check mean "this run produced a frame". The launcher runs as the service
+# user, so it exercises the same venv, browser cache and permissions the timer
+# will.
+if ! "$LAUNCHER" --force; then
+  echo "The first render failed. Diagnose with:  journalctl -u $SERVICE -n 40" >&2
+  exit 1
+fi
+# Belt and braces: prove a real PNG landed, and that it landed *now*. A dangling
+# symlink and a missing file both come back 200 text/html through Caddy's
+# try_files, so "the file is there" is the only thing that distinguishes a
+# working publisher from one that silently serves the HTML shell.
+if [ ! -s "$OUT" ] || [ "$(head -c4 "$OUT" | od -An -tx1 | tr -d ' \n')" != "89504e47" ]; then
+  echo "no PNG at $OUT after the first run." >&2
+  echo "Diagnose with:  journalctl -u $SERVICE -n 40" >&2
+  exit 1
+fi
+if [ "$(stat -c %Y "$OUT")" = "$BEFORE" ]; then
+  echo "warning: $OUT was not updated by this run; it may be stale." >&2
+fi
+# Now prove the unit wiring itself, separately from the render. This one will
+# normally log "no change; skip" - that is the gate working, not a failure.
+if ! sudo systemctl start "$SERVICE"; then
+  echo "The systemd unit failed to run. Diagnose with:  journalctl -u $SERVICE -n 40" >&2
+  exit 1
+fi
+# Starting the timer trips OnBootSec=3min, which is always in the past on a
+# running machine, so this fires one extra service run immediately. It is a
+# gated tick costing a fraction of a second, and it happens after the checks
+# above, so it proves rather than pre-empts them.
+[ "$ENABLE" = 1 ] && [ "$ACTION" != refresh ] && sudo systemctl start "$TIMER"
+
+# Prefer the tailnet name when there is one: it works off-LAN and has a real
+# certificate. Never hardcode a tailnet - read it from the daemon.
+PUB=""
+if command -v tailscale >/dev/null 2>&1; then
+  TS="$(tailscale status --json 2>/dev/null \
+        | python3 -c 'import json,sys;print(json.load(sys.stdin)["Self"]["DNSName"].rstrip("."))' 2>/dev/null || true)"
+  [ -n "$TS" ] && PUB="https://$TS/frame.png"
+fi
+[ -n "$PUB" ] || PUB="http://$(hostname -I | awk '{print $1}')/frame.png"
+
+cat <<DONE
+
+Installed. This Pi re-checks for new birds every ${INTERVAL:-15min} and
+re-renders only when they change. The frame is published at
+  $PUB
+
+On the frame Pi, run:
+  ./install.sh --image-url $PUB
+
+Retune titles in $ENV_FILE, then: sudo systemctl start $SERVICE
+DONE
+if grep -qs 'frame.png' "$FRAME/../scripts/update_caddyfile.sh"; then
+  cat <<DONE
+Optional: sudo $FRAME/../scripts/update_caddyfile.sh
+          adds a no-cache header for /frame.png (regenerates the whole Caddyfile).
+DONE
+fi

--- a/frame/install-publish.sh
+++ b/frame/install-publish.sh
@@ -351,11 +351,14 @@ if [ -n "$INTERVAL" ]; then
 #
 # The bare assignment first is load-bearing: these are LIST-valued settings, so
 # a plain OnUnitActiveSec= in a drop-in APPENDS a second trigger instead of
-# replacing the shipped 15min one. Without the reset, a longer interval would
-# silently do nothing (15min still elapses first) while the installer claimed
-# otherwise. The reset also clears OnBootSec=, so it is restated here.
+# replacing the shipped one. Without the reset, a longer interval would silently
+# do nothing (the shipped value still elapses first) while the installer claimed
+# otherwise. The reset clears the whole monotonic list, so OnActiveSec= and
+# OnBootSec= have to be restated - dropping OnActiveSec here would reintroduce
+# the stopped-and-restarted deadlock the shipped timer exists to avoid.
 [Timer]
 OnUnitActiveSec=
+OnActiveSec=3min
 OnBootSec=3min
 OnUnitActiveSec=$INTERVAL
 DROPIN

--- a/frame/publish.py
+++ b/frame/publish.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Render the collage on the mic Pi and publish it in the site's own web root.
+
+The frame Pi (a Zero 2 W or 3 A+) needs ~70-120s and ~300MB of Chromium to
+shoot the collage itself. The mic Pi already serves the page and is usually a
+4/5, so it renders in seconds - this runs there on a timer and drops the PNG
+where Caddy already serves every other static asset. The frame Pi then runs in
+image_url mode with no browser at all.
+
+This is also the *only* place the refresh is decided. frame.png changes only
+when the birds change, so the frame Pi can gate on the image itself (a
+conditional GET) instead of re-deriving the same answer from the API on its own
+clock. Two gates on two machines race: a bird arriving between the last render
+and the frame Pi's poll flips its signature while the published image still
+predates the bird, and the panel is then stranded on the stale collage until the
+next species change or the daily heal, with both machines logging success.
+
+Settings come from the environment first (FRAME_URL, FRAME_OUT, ...) so the
+systemd unit can pass no arguments at all and /etc/birdframe/publish.env is the
+whole tuning surface; CLI flags override for hand runs.
+
+  publish.py --out ~/BirdSongs/frame/frame.png --force
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import re
+import struct
+import sys
+import time
+
+from shoot import shoot
+# The gate is display.py's, imported rather than reimplemented: both machines
+# must bucket call counts identically or the frame Pi's heal is the only thing
+# that ever corrects a disagreement. display.py imports PIL at module scope
+# (hence Pillow in requirements-publish.txt) but imports inky lazily inside
+# push_panel, so this is safe on a machine with no panel.
+from display import _auth, fetch_recent, signature, load_state, save_state
+
+# The panel is 1200x1600 and display.py silently resizes anything else, so a
+# viewport or device-scale-factor regression would ship soft with no error.
+PANEL_W, PANEL_H = 1200, 1600
+
+DEFAULT_URL = "http://127.0.0.1/"          # this Pi's own site; see main()
+DEFAULT_TITLE = "Avian Visitors"
+DEFAULT_SUBTITLE = "Heard Today"
+# 0.65 matches display.py's shoot_count_exp and the countExp already in apt.js.
+# shoot.py's own default is 0.4, which would flatten the size hierarchy - the
+# frame has to look identical whichever Pi rendered it.
+DEFAULT_COUNT_EXP = 0.65
+# Playwright applies this to each step separately (goto, the tile wait, the
+# image wait), so a run can legitimately take ~3x this plus browser launch.
+# TimeoutStartSec in the unit is sized off that, not off this number.
+DEFAULT_TIMEOUT_MS = 60000
+DEFAULT_HOURS = 24                         # matches display.py and the page's own default
+# Re-render at least this often even when the birds have not moved, mirroring
+# display.py's heal_hours. Without it a frame.png truncated by a full disk, or
+# clobbered by something else, is never repaired for as long as the species set
+# holds - and the gate would keep reporting "no change" over the damage.
+DEFAULT_HEAL_HOURS = 24
+
+
+def recs_dir(conf="/etc/birdnet/birdnet.conf"):
+    """RECS_DIR from birdnet.conf, so the default output path is never a
+    hardcoded ~/BirdSongs - installs relocate it.
+
+    The real file lives here rather than in EXTRACTED (the web root);
+    install-publish.sh symlinks it in, which is the same shape spectrogram.png
+    already uses. Keeping it out of the root also keeps the lock and temp files
+    off the file_server listing.
+    """
+    try:
+        with open(conf) as f:
+            for line in f:
+                m = re.match(r'\s*RECS_DIR=([^#]*)', line)
+                if m:
+                    return os.path.expandvars(m.group(1).strip().strip('"\''))
+    except OSError:
+        pass
+    return os.path.expanduser("~/BirdSongs")
+
+
+def png_size(path):
+    """(width, height) straight out of the PNG IHDR, without decoding 1.5MB of
+    image data to learn two integers."""
+    with open(path, "rb") as f:
+        head = f.read(24)
+    if len(head) < 24 or head[:8] != b"\x89PNG\r\n\x1a\n" or head[12:16] != b"IHDR":
+        raise RuntimeError(f"{path} is not a PNG")
+    return struct.unpack(">II", head[16:24])
+
+
+def sweep(out):
+    """Remove a temp render a previous run left behind. publish() cleans up
+    after itself on any *exception*, but systemd's TimeoutStartSec sends SIGTERM
+    and a cgroup OOM sends SIGKILL - neither runs `finally`, so without this a
+    killed render leaks 1.5MB next to the published frame every time."""
+    try:
+        os.unlink(f"{out}.tmp.png")
+    except OSError:
+        pass
+
+
+def publish(url, out, **look):
+    """Shoot into a sibling temp file, sanity-check it, then swap it in.
+
+    Anything that raises leaves the published frame - and its mtime - exactly as
+    they were, which is what lets the frame Pi keep showing the last good image
+    through an outage.
+    """
+    # Sibling, not /tmp: os.replace is only atomic within one filesystem and
+    # /tmp is a separate tmpfs here. A fixed name is safe because the flock in
+    # main() already guarantees one publisher at a time, and a fixed name is
+    # what makes the sweep above able to find it. It has to keep a .png
+    # extension: shoot() hands the path straight to page.screenshot(), and
+    # Playwright infers the image format from it - a bare ".tmp" is rejected
+    # as an unsupported mime type before a single pixel is rendered.
+    tmp = f"{out}.tmp.png"
+    try:
+        shoot(url, tmp, **look)
+        w, h = png_size(tmp)
+        if (w, h) != (PANEL_W, PANEL_H):
+            raise RuntimeError(f"render is {w}x{h}, expected {PANEL_W}x{PANEL_H}")
+        size = os.path.getsize(tmp)
+        # Deliberately no "this looks too small, reject it" guard. A big drop in
+        # PNG size is normal - twelve species at dawn against two at 4am on a
+        # rolling 24h window, a quiet winter day, or the birdless title card
+        # shoot.py renders on purpose. Any such guard compares against the last
+        # *published* frame, which by definition never updates while the guard
+        # is firing, so one legitimate small render would wedge publishing
+        # permanently and burn a Chromium launch every tick forever. Log the
+        # size instead and let a human spot a run of tiny frames in the journal.
+        os.chmod(tmp, 0o644)  # caddy is in the birdnet group; a tight umask would 403
+        os.replace(tmp, out)
+    finally:
+        try:
+            os.unlink(tmp)  # a failed shoot must not leave litter next to the frame
+        except OSError:
+            pass  # never mask the real render error with a cleanup error
+    return size
+
+
+def changed(url, out, state_path, hours, timeout_ms, heal_hours, auth=None):
+    """(should_render, signature) - has the bird set moved since the last publish?
+
+    The signature is fetched even when we already know we must render (no frame
+    on disk yet), so the first successful publish records it and the second tick
+    is a cheap skip instead of a redundant render.
+
+    A fetch that fails is treated as "no change" when a frame already exists,
+    matching display.py: a blip in the API must not trigger a render storm, and
+    the published frame is still valid. With no frame at all we render anyway -
+    an unpublished frame is worse than a possibly-redundant render.
+    """
+    state = load_state(state_path)
+    # A frame that has gone stale past the heal window is re-rendered whatever
+    # the signature says, so damage the gate cannot see gets repaired daily.
+    due = time.time() - state.get("last_refresh", 0) >= heal_hours * 3600
+    first_run = not os.path.exists(out)
+    try:
+        # auth matters: on a site behind basic auth an unauthenticated gate fetch
+        # 401s every tick, which reads as "no change" and freezes the frame on
+        # whatever the first run published - forever, with both machines
+        # reporting success. That is the exact failure this file exists to avoid.
+        sig = signature(fetch_recent(url, hours, timeout_ms / 1000, auth))
+    except Exception as e:
+        print(f"signature fetch failed: {e}", file=sys.stderr)
+        return first_run or due, None
+    return first_run or due or sig != state.get("signature"), sig
+
+
+def env_default(name, fallback, cast=str):
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return fallback
+    try:
+        return cast(raw)
+    except ValueError:
+        print(f"{name}={raw!r} is not valid; using {fallback!r}", file=sys.stderr)
+        return fallback
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Render frame.png and publish it in the web root.",
+        epilog="Every option also reads an env var (FRAME_URL, FRAME_OUT, ...), "
+               "so the systemd unit passes no arguments and /etc/birdframe/publish.env "
+               "is the tuning surface. Flags win over the environment.")
+    # 127.0.0.1, not birdnet.local: the site is on this machine, and avahi may
+    # not be answering yet when the timer first fires after boot.
+    ap.add_argument("--url", default=env_default("FRAME_URL", DEFAULT_URL))
+    ap.add_argument("--out", default=env_default(
+        "FRAME_OUT", os.path.join(recs_dir(), "frame", "frame.png")))
+    ap.add_argument("--state", default=env_default(
+        "FRAME_STATE", "~/.birdframe/publish-state.json"),
+        help="publisher's own gate state; NOT the frame Pi's state.json")
+    ap.add_argument("--title", default=env_default("FRAME_TITLE", DEFAULT_TITLE))
+    ap.add_argument("--subtitle", default=env_default("FRAME_SUBTITLE", DEFAULT_SUBTITLE))
+    ap.add_argument("--hours", type=int, default=env_default("FRAME_HOURS", DEFAULT_HOURS, int),
+                    help="detection window used for the change gate")
+    ap.add_argument("--headline-px", type=int, default=env_default("FRAME_HEADLINE_PX", 42, int))
+    ap.add_argument("--eyebrow-px", type=int, default=env_default("FRAME_EYEBROW_PX", 18, int))
+    # BooleanOptionalAction, not store_true: with an env-derived default of True
+    # a store_true flag is a no-op and there is no way to turn it back off from
+    # the command line. This gives --lowercase / --no-lowercase.
+    ap.add_argument("--lowercase", action=argparse.BooleanOptionalAction,
+                    default=env_default("FRAME_LOWERCASE", "", str).lower()
+                    in ("1", "true", "yes", "on"))
+    ap.add_argument("--mat", type=float, default=env_default("FRAME_MAT", 0.04, float))
+    ap.add_argument("--small-floor", type=float, default=env_default("FRAME_SMALL_FLOOR", 0.04, float))
+    ap.add_argument("--count-exp", type=float,
+                    default=env_default("FRAME_COUNT_EXP", DEFAULT_COUNT_EXP, float))
+    ap.add_argument("--timeout", type=int,
+                    default=env_default("FRAME_TIMEOUT_MS", DEFAULT_TIMEOUT_MS, int),
+                    help="milliseconds, applied per Playwright step")
+    ap.add_argument("--heal-hours", type=float,
+                    default=env_default("FRAME_HEAL_HOURS", DEFAULT_HEAL_HOURS, float),
+                    help="re-render at least this often even with no bird change")
+    ap.add_argument("--user", default=env_default("FRAME_USER", None))
+    ap.add_argument("--password", default=env_default("FRAME_PASSWORD", None))
+    ap.add_argument("--force", action="store_true", help="render even if the birds have not changed")
+    a = ap.parse_args()
+
+    out = os.path.abspath(os.path.expanduser(a.out))
+    state_path = os.path.expanduser(a.state)
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    # `or "."` because --state may be a bare filename, and os.makedirs("") raises.
+    os.makedirs(os.path.dirname(state_path) or ".", exist_ok=True)
+    auth = _auth({"basic_user": a.user, "basic_pass": a.password})
+
+    # systemd already refuses to start a second copy of a oneshot that is still
+    # running, so this only guards a hand-run publish racing the timer: two
+    # chromiums at once on a Pi that is also doing realtime tflite inference.
+    # Deliberately NOT display.py's .render.lock - that one serialises panel
+    # pushes, and sharing the name would deadlock a combined install. It sits
+    # beside the state file rather than the output, because the output directory
+    # may be inside the web root on a custom FRAME_OUT and a lock file has no
+    # business being fetchable.
+    lock = open(os.path.join(os.path.dirname(state_path) or ".", ".publish.lock"), "w")
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        print("another publish is in progress; skipping")
+        return
+
+    sweep(out)
+
+    # The signature is fetched even under --force, so a hand-forced render still
+    # records where the birds were; otherwise the next timer tick sees the stale
+    # recorded signature and renders a second time for nothing.
+    moved, sig = changed(a.url, out, state_path, a.hours, a.timeout, a.heal_hours, auth)
+    if not (a.force or moved):
+        print("no change; skip")
+        return
+
+    try:
+        size = publish(a.url, out, title=a.title, subtitle=a.subtitle,
+                       headline_px=a.headline_px, eyebrow_px=a.eyebrow_px,
+                       lowercase=a.lowercase, mat=a.mat, small_floor=a.small_floor,
+                       count_exp=a.count_exp, timeout_ms=a.timeout,
+                       # The gate hashes `hours` of detections, so the render has
+                       # to cover the same window or a change outside the drawn
+                       # window triggers a full repaint of an identical collage.
+                       window_hours=a.hours,
+                       user=a.user, password=a.password)
+    except Exception as e:
+        # Non-zero so `systemctl --failed` surfaces it. The previous frame.png is
+        # still published and the frame Pi keeps showing it.
+        print(f"publish failed, keeping the last frame: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Only after a successful publish, so a failed render is retried next tick
+    # instead of being recorded as done.
+    if sig is not None:
+        save_state(state_path, sig, time.time())
+    print(f"published {out} ({size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/frame/requirements-publish.txt
+++ b/frame/requirements-publish.txt
@@ -1,0 +1,9 @@
+# Publish host: the BirdNET mic Pi, rendering frame.png for a frame Pi that has
+# no browser (frame/install-publish.sh). Same headless-Chromium requirement as
+# the screenshot host, plus Pillow - publish.py imports display.py's change
+# detection rather than duplicating its count bucketing, and display.py imports
+# PIL at module scope. Deliberately NOT requirements-frame.txt: this machine has
+# no panel and must not pull in inky/numpy/spidev.
+-r requirements-shoot.txt
+Pillow>=10,<12
+tomli; python_version < "3.11"

--- a/frame/requirements-shoot.txt
+++ b/frame/requirements-shoot.txt
@@ -1,4 +1,8 @@
 # Screenshot host: shoot.py. Any 64-bit machine that can run headless Chromium
 # (a Pi 4/5, a laptop, a small server). NOT a Pi Zero W (no ARMv6 browser).
+# On a BirdNET mic Pi publishing for a frame, install-publish.sh installs
+# requirements-publish.txt instead, which pulls this in.
 #   pip install -r requirements-shoot.txt && playwright install chromium
-playwright>=1.40
+# Note `frame/install.sh` installs playwright directly rather than through this
+# file, so the bound below only governs the publish host.
+playwright>=1.40,<2

--- a/frame/systemd/birdframe-publish.service
+++ b/frame/systemd/birdframe-publish.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=AvianVisitors: render frame.png and publish it in the web root
+Documentation=https://github.com/Twarner491/AvianVisitors
+# The shot is of this Pi's OWN site, so waiting for the network is not enough -
+# a run that fires before caddy is listening screenshots a 502.
+Wants=network-online.target
+After=network-online.target caddy.service
+
+[Service]
+Type=oneshot
+# This file ships unmodified and must be valid on any install, so it carries no
+# home directory, no user, and no schedule. install-publish.sh writes the three
+# machine-specific pieces instead:
+#   /usr/local/bin/birdframe-publish                  where the clone and venv are
+#   birdframe-publish.service.d/10-local.conf         User=
+#   /etc/birdframe/publish.env                        title, subtitle, url, out
+# Retune the frame by editing publish.env; `systemctl edit` for anything else.
+EnvironmentFile=-/etc/birdframe/publish.env
+ExecStart=/usr/local/bin/birdframe-publish
+# Unbuffered so shoot.py's stderr ("site returned 502", "some illustrations did
+# not finish loading") lands in the journal in order instead of after the exit.
+Environment=PYTHONUNBUFFERED=1
+# This Pi runs realtime tflite inference and writes WAV segments to the same
+# card. A screenshot must never win CPU or IO against either; a slow frame is
+# invisible, a dropped detection is not.
+Nice=10
+IOSchedulingClass=idle
+# No MemoryMax. Chromium here peaks well under what a 4/5 has spare, and a
+# cgroup kill is SIGKILL: it would skip publish.py's cleanup and leave
+# Playwright's profile in the /tmp tmpfs, i.e. in RAM, until reboot.
+#
+# publish.py applies its timeout to EACH Playwright step (goto, the tile wait,
+# the image wait), so the default 60s/step is ~200s worst case plus browser
+# launch. Keep systemd's kill above that or a slow render dies with nothing in
+# the journal to explain it.
+TimeoutStartSec=300
+
+# No [Install] section: this is driven by birdframe-publish.timer, not enabled
+# directly.

--- a/frame/systemd/birdframe-publish.timer
+++ b/frame/systemd/birdframe-publish.timer
@@ -2,6 +2,13 @@
 Description=Re-render the published bird frame on a schedule
 
 [Timer]
+# Give every activation its own bootstrap deadline. OnBootSec= fires once per
+# boot and OnUnitActiveSec= counts from the service's last activation, so that
+# pair alone leaves no pending trigger if the timer is stopped and started again
+# without a reboot - it sits 'active (elapsed)' with no next deadline and the
+# frame silently stops updating. Same fix as birdframe.timer (#47), which traced
+# two multi-day frame stalls to exactly this.
+OnActiveSec=3min
 # 3 min, not 2: caddy, php-fpm and the first analysis pass all have to be up, or
 # the first frame of every boot is a screenshot of a 502.
 OnBootSec=3min

--- a/frame/systemd/birdframe-publish.timer
+++ b/frame/systemd/birdframe-publish.timer
@@ -1,0 +1,21 @@
+[Unit]
+Description=Re-render the published bird frame on a schedule
+
+[Timer]
+# 3 min, not 2: caddy, php-fpm and the first analysis pass all have to be up, or
+# the first frame of every boot is a screenshot of a 502.
+OnBootSec=3min
+# Measured on a Pi 5: a gated tick that finds no new birds costs 0.27s (one JSON
+# request to 127.0.0.1, no browser), and a full render 1.8s. So the interval is
+# not a cost question, it is a freshness one: worst-case bird-to-panel latency is
+# this plus the frame Pi's own 15min poll. 5min keeps that around 20min without
+# the publisher being noticeable on a Pi also running realtime tflite inference.
+# Raise it on a Pi 3 or a busy box; `install-publish.sh --interval` writes a
+# drop-in, this file is never edited in place.
+OnUnitActiveSec=5min
+# Harmless here (Persistent= only acts on OnCalendar=), kept for symmetry with
+# birdframe.timer.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install_birdnet.sh
+++ b/scripts/install_birdnet.sh
@@ -58,4 +58,22 @@ CURRENT_TIMEZONE=$(timedatectl show --value --property=Timezone)
 
 ./install_language_label.sh || exit 1
 
+# Optional: render frame.png here on a timer and publish it, so an e-ink wall
+# frame can run with no browser (frame/README.md). Off by default because it
+# pulls ~300MB of Chromium, so it is opt-in through the environment:
+#   FRAME_PUBLISH=15min ./newinstaller.sh
+# All the logic stays in frame/; this is only the hook. A failure here must not
+# fail the BirdNET install - the frame is an accessory.
+if [ -n "${FRAME_PUBLISH:-}" ]; then
+  # The variable takes an interval, but "=1" / "=yes" / "=true" are what people
+  # actually type for an opt-in flag. Treat those as "use the default" rather
+  # than failing validation inside a 20-40 minute install log nobody reads.
+  case "${FRAME_PUBLISH,,}" in
+    1|y|yes|true|on) FRAME_INTERVAL=15min ;;
+    *) FRAME_INTERVAL="$FRAME_PUBLISH" ;;
+  esac
+  "$HOME"/BirdNET-Pi/frame/install-publish.sh --interval "$FRAME_INTERVAL" \
+    || echo "frame publisher install failed; BirdNET-Pi itself is fine. See frame/README.md" >&2
+fi
+
 exit 0

--- a/scripts/link_webroot.sh
+++ b/scripts/link_webroot.sh
@@ -116,6 +116,34 @@ link_avian_visitors_webroot() {
     _avian_link_one "${run_user}" \
       "${sources[$index]}" "${web_root}/${targets[$index]}" || return 1
   done
+
+  # The published e-ink frame (frame/install-publish.sh), deliberately outside
+  # the manifest above. Its source is generated under RECS_DIR rather than
+  # shipped in the repo, and it is absent before the first publish and after
+  # clear_all_data.sh - inside the manifest a missing frame would fail the
+  # validation pass and leave the entire webroot unlinked.
+  #
+  # RECS_DIR is read here, not taken from the caller: every caller now invokes
+  # this file as an out-of-process helper, so nothing exports it.
+  if [ -x /usr/local/bin/birdframe-publish ]; then
+    local recs_conf=/etc/birdnet/birdnet.conf recs_dir=""
+    [ -r "$recs_conf" ] && recs_dir=$(awk -F= '/^[[:space:]]*RECS_DIR[[:space:]]*=/ {
+      value=$0; sub(/^[^=]*=/, "", value); gsub(/^[[:space:]"\047 ]+|[[:space:]"\047 ]+$/, "", value); print value; exit
+    }' "$recs_conf")
+    if [ -z "$recs_dir" ]; then
+      echo "Warning: RECS_DIR not found; skipping the frame link" >&2
+    elif [ -d "${web_root}/frame.png" ] && [ ! -L "${web_root}/frame.png" ]; then
+      echo "Refusing to replace directory: ${web_root}/frame.png" >&2
+    else
+      # Explicit mode: the update path runs under `umask 077`, which would leave
+      # this 0700 and stop caddy (a member of the station group) traversing it -
+      # /frame.png would then fall through to index.php and serve HTML.
+      if ! sudo -u "${run_user}" mkdir -m 0755 -p "${recs_dir}/frame" \
+        || ! sudo -u "${run_user}" ln -sfn "${recs_dir}/frame/frame.png" "${web_root}/frame.png"; then
+        echo "Warning: could not relink ${web_root}/frame.png" >&2
+      fi
+    fi
+  fi
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/scripts/update_caddyfile.sh
+++ b/scripts/update_caddyfile.sh
@@ -631,6 +631,14 @@ ${site_overlay_import}  root * $EXTRACTED
   @shell path / /index.html
   header @shell Cache-Control "no-cache"
 
+  # The published frame (frame/install-publish.sh) is re-rendered on a timer, so
+  # a heuristically-cached copy shows yesterday's birds. no-cache forces
+  # revalidation while still allowing the 304 the frame Pi's conditional GET
+  # relies on. A no-op where the publisher was never installed and the path does
+  # not exist.
+  @frame path /frame.png
+  header @frame Cache-Control "no-cache"
+
   # BirdNET-Pi's older PHP tools and reverse-proxied consoles do not share
   # AvianVisitors' session gate. Protect the whole legacy surface with the
   # configured password, or limit it to direct read pages when none exists.


### PR DESCRIPTION
Lets the BirdNET mic Pi draw the frame image and serve it, so the frame Pi can use the existing `--image-url` mode and doesn't need a browser at all.

On a Zero 2 W, taking the screenshot needs 70–120 seconds and about a gigabyte of Chromium — that's why #30 had to raise the timeout to 180s. A Pi 4 or 5 mic is already serving the page and does the same job in **1.8 seconds**, so it may as well do it.

The mic Pi checks every few minutes whether the birds have changed. If they haven't, it stops there and never starts a browser. If they have, it draws a new image and swaps it into place. The frame Pi downloads that image and updates the panel.

### Install

```bash
cd ~/BirdNET-Pi/frame && ./install-publish.sh     # --interval 15min to slow it down
./install-publish.sh --uninstall                   # undoes everything
```

Then on the frame Pi: `./install.sh --image-url <the URL it prints>`.

### Only one thing decides when to refresh

Before, the frame Pi asked the mic Pi's API whether the birds had changed. But the image it downloads was drawn earlier, so the two could disagree — a bird arriving in between made the frame Pi refresh to a picture taken *before* that bird, and the panel stayed wrong until the next change or the next day. Both machines reported success.

Now the mic Pi is the only one deciding. The image changes only when the birds do, so the frame Pi just asks "has this file changed since last time?" and skips the panel refresh if it hasn't. As a bonus, it no longer needs to reach the mic Pi's API at all. The other three modes are unchanged.

### The unit files work anywhere

`frame/systemd/birdframe.service` currently has the author's own username and home directory baked in, and `install.sh` edits them out at install time — so the committed file isn't valid on anyone's machine. The new ones avoid that. systemd won't accept relative paths, so instead of templating the unit, the per-machine bits live in three small generated files: a launcher script, a one-line drop-in for the username, and a settings file at `/etc/birdframe/publish.env` you can edit. After installing, the installed units are identical to the committed ones.

### Tested on a real Pi 5

Installed and left running against a live BirdNET-Pi:

- Image served over both the local network and Tailscale, and it matches the file on disk
- Repeat downloads correctly return "not changed" and skip the panel refresh; after a redraw, the frame Pi picks up the new image
- With the web server stopped, it fails cleanly and the previous image is untouched — which is what keeps the panel showing something sensible during an outage
- Preview render is the right size and uses exactly the six e-ink colours
- Timer fires on the interval you asked for

Not tested: the Chromium download itself, since it was already cached on the test machine.

### Worth a look during review

- The timer's interval setting **adds to** the built-in one rather than replacing it, so the drop-in has to clear it first. Otherwise asking for a *longer* interval quietly does nothing.
- A missing `frame.png` doesn't return a 404 here — the web server falls back to the main page, so you get a web page where an image should be. `display.py` now says so plainly instead of failing with a confusing image error.
- Chromium's downloaded browser is stored per user, so running the publisher by hand with `sudo` fails with a misleading message. It now refuses and tells you what to run instead.
- There's deliberately **no** "this image looks too small, reject it" check. A big size drop is normal — twelve birds at dawn versus two at 4am — and any such check compares against the last good image, which never updates while the check is failing. One unusually small image would jam it permanently.

### Rebased onto current avian-visitors

Upstream moved ~40 commits ahead, so this was rebased and four files needed resolving. All four were small additions landing in files that had been rewritten around them:

- **`update_caddyfile.sh`** — the two site-block heredocs are now one, so the `no-cache` block is inserted once rather than twice. Confirmed `/frame.png` is still reachable: the new `handle /assets/*` and `handle /avian/assets/*` rules don't cover the web root, and the catch-all `handle { php_fastcgi; file_server }` still serves it. Both generated variants pass `caddy validate`.
- **`link_webroot.sh`** — now validates its whole manifest before linking anything, so a missing source aborts the lot. The frame link deliberately sits *outside* that manifest: its target is generated under `RECS_DIR` and is absent before the first publish and after a data reset, so including it would leave the entire webroot unlinked whenever the frame was missing.
- **`update_birdnet_snippets.sh`** — now a 32-line shim into the verified refresher, so the refresh hook is dropped. See the caveat below.
- **`frame/README.md`** — publish-mode section moved below the new `opening` and `birdframe-names` paragraphs.

### Also picked up from upstream

- **#47** found that `OnBootSec=` plus `OnUnitActiveSec=` alone leaves a timer with no next deadline once it's stopped and restarted without a reboot. The publish timer had the same pair, so it had the same bug. Fixed with `OnActiveSec=`, restated in the `--interval` drop-in since the reset there clears the whole list.
- **#43** added `link_webroot.sh` so install and data-reset can't drift; the frame symlink now lives there too.
- **Bird names.** The gate here routes image mode straight to the fetch and never reaches `obtain_image`, so upstream's new `frame_url()` rewrite was being skipped and the label preference would have stopped reaching the source entirely — a clean merge that silently drops a feature. Now applied in the gate, and the stored validators are pinned to the URL they came from, since toggling labels changes the URL but not the file, leaving the ETag a match.

### Two honest limitations

- **This source ignores `labels=`.** It serves one pre-rendered PNG, so `birdframe-names` against a frame pointed at it will report success and change nothing — exactly what `frame/README.md` warns can happen. Set names on the mic Pi instead. Publishing a second labelled variant is a better fix and belongs in its own PR.
- **Existing publishers keep their old units until `install-publish.sh --refresh` is run by hand.** Dropping the updater hook means the `OnActiveSec=` fix above doesn't reach an already-installed publisher through an ordinary update. Wiring it into the new refresher would need a root-owned fixed-action helper, which is more than this PR should take on.

### Left for later

Cleaning up `birdframe.service`'s hardcoded paths, and its timeout, which is set lower than a slow render can actually take. Both are worth fixing but don't belong in a change that adds a new mode.

Independent of #49. #61 also wires `window_hours` into the shoot path, and the two are complementary rather than overlapping — it fixes the frame Pi's own render, this passes the same argument from the publisher so the change-detection window and the drawn window agree. Trial-merged both directions: clean, and both orders produce an identical tree, so merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uo5ZA3u3Tk2GUZw87CMNF


