### PR TITLE
gitignore: exclude the artifacts install generates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ IdentifiedSoFar.txt.bak
 Birders_Guide_Installer_Configuration.txt
 birdnet/
 templates/*.service
+# Written per-host by install_birdnet_mount(), with the filename derived from
+# RECS_DIR - same reason the generated .service units above are not committed.
+templates/*.mount
 scripts/*.txt
 scripts/*.db
 analyzing_now.txt
@@ -57,3 +60,11 @@ whitelist_species_list.txt
 avian/assets/references/
 # Superseded assets retained locally
 avian/assets/_legacy/
+
+# --- Generated at install time, never committed ---
+# get_tf_whl() curls the wheel matching this machine's arch and Python version,
+# then rewrites requirements.txt into requirements_custom.txt pointing at it.
+# Both are per-machine build output; committing either would pin every install
+# to whatever hardware happened to produce them.
+tflite_runtime-*.whl
+requirements_custom.txt


### PR DESCRIPTION
Three files show up as untracked on every real install, so `git status` is never clean:

| | |
|---|---|
| `tflite_runtime-*.whl` | curled by `get_tf_whl()` for the machine's arch and Python version |
| `requirements_custom.txt` | generated from `requirements.txt` in the same step, pointing at that wheel |
| `templates/*.mount` | written by `install_birdnet_mount()`, filename derived from `RECS_DIR` |

All three are per-machine build output — committing any of them would pin every install to whatever hardware produced it. The generated `.service` units on the line above are already excluded for exactly this reason; the `.mount` unit was just missed when it was added.

Checked that no currently-tracked file matches any of the three patterns, so nothing already in the index is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uo5ZA3u3Tk2GUZw87CMNF