### PR TITLE
Add Canberra / ACT, Australia (AU-ACT) illustration bundle

### DIFF
--- a/illustration-bundles.md
+++ b/illustration-bundles.md
@@ -22,3 +22,4 @@ The main repo ships a Western-US set reviewed by hand. Other people have generat
 ## Oceania
 
 - **Victoria, Australia (AU-VIC)**: [TheWillni's repo](https://github.com/TheWillni/AusVicVisitors), not a full fork but just the illustrations, `dims.json` and `masks.json` for 398 species from Victoria, Australia (AU-VIC).
+- **Canberra / ACT, Australia (AU-ACT)**: [opurtell's repo](https://github.com/opurtell/AvianVisitorsACT), the `avian/` overlay only, for 403 species. The AU-VIC bundle above plus the 5 species it was missing (Australasian Pipit, Cattle Egret, Variegated Fairywren, Intermediate Egret, Barn Owl). Covers everything BirdNET attempts at Canberra with `DATA_MODEL_VERSION=2`. Also ships the species derivation and a ready-made `include_species_list.txt` for the region.


### PR DESCRIPTION
Adds an AU-ACT entry under Oceania.

403 species — the AU-VIC bundle plus the 5 species it was missing:
Australasian Pipit, Cattle Egret, Variegated Fairywren, Intermediate Egret and
Barn Owl. Each of those is a BirdNET label with no art in the AU-VIC set, so
detections were falling through to the photo-cutout path. They are offered
back to that bundle in TheWillni/AusVicVisitors#10, since they are not
ACT-specific birds.

Covers everything BirdNET attempts at Canberra (-35.28, 149.13) with
`SF_THRESH=0.03` and `DATA_MODEL_VERSION=2` — 197 species, all with both
poses.

The repo is the `avian/` overlay only rather than a full fork, so it drops
straight onto an existing install with rsync. Alongside the art it carries the
species derivation, a ready-made BirdNET-Pi `include_species_list.txt` for the
region, and a deployment write-up.

One finding that may be worth folding into the main docs independently of this
entry: the installer defaults to `DATA_MODEL_VERSION=1`
(`scripts/install_config.sh:48`), and at Canberra v1 offers 127 species
against v2's 197, while scoring Holarctic birds like *Bombycilla garrulus* and
*Lagopus lagopus* above species that genuinely occur locally. v1 looks
noticeably worse than v2 for Australian deployments. Happy to open that
separately if useful.
