### PR TITLE
[FIX] updater: keep verified fetches off tmpfs

### DIFF
--- a/scripts/bootstrap_v1.sh
+++ b/scripts/bootstrap_v1.sh
@@ -58,7 +58,7 @@ case "$configured_origin" in
   *) die "origin must be $OFFICIAL_ORIGIN" ;;
 esac
 
-work_dir=$(mktemp -d /tmp/avian-v1-bootstrap.XXXXXX)
+work_dir=$(mktemp -d /var/tmp/avian-v1-bootstrap.XXXXXX)
 trusted_repo=$work_dir/official.git
 cleanup() { rm -rf "$work_dir"; }
 trap cleanup EXIT
@@ -88,4 +88,6 @@ for index in "${!sources[@]}"; do
   mv -f "$temp_target" "$target"
 done
 
+cleanup
+trap - EXIT
 exec "$UPDATE_HELPER"

--- a/scripts/reinstall_services.sh
+++ b/scripts/reinstall_services.sh
@@ -138,7 +138,7 @@ current_head=$(git_station rev-parse --verify HEAD)
 # Privileged helper bytes must not be trusted merely because they are clean in
 # a station-owned checkout. Fetch the official release into a root-owned
 # temporary object store, then require the checkout to be on that exact commit.
-work_dir=$(mktemp -d /tmp/avian-service-refresh.XXXXXX)
+work_dir=$(mktemp -d /var/tmp/avian-service-refresh.XXXXXX)
 trusted_repo=$work_dir/official.git
 cleanup() { rm -rf "$work_dir"; }
 trap cleanup EXIT

--- a/tests/smoke_pre_v1_bootstrap.sh
+++ b/tests/smoke_pre_v1_bootstrap.sh
@@ -121,7 +121,20 @@ cat >/usr/local/bin/systemctl <<'EOF'
 printf '%s\n' "$*" >>/tmp/avian-pre-v1-bootstrap/systemctl.log
 exit 0
 EOF
-chmod 0755 /usr/local/bin/systemctl
+cat >/usr/local/bin/mktemp <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  case "$argument" in
+    /tmp/avian-v1-bootstrap.*|/tmp/avian-service-refresh.*)
+      echo 'large verified fetch attempted to use /tmp' >&2
+      exit 88
+      ;;
+  esac
+done
+printf '%s\n' "$*" >>/tmp/avian-pre-v1-bootstrap/mktemp.log
+exec /usr/bin/mktemp "$@"
+EOF
+chmod 0755 /usr/local/bin/systemctl /usr/local/bin/mktemp
 
 runuser -u "$station_user" -- env HOME="$station_home" \
   USER="$station_user" PATH=/usr/local/bin:/usr/bin:/bin \
@@ -190,6 +203,16 @@ chmod 0440 /etc/sudoers.d/010_caddy-nopasswd
 
 bash /source/scripts/bootstrap_v1.sh >"$test_root/bootstrap.log" 2>&1 \
   || { cp "$test_root/bootstrap.log" "$test_root/update.log"; fail 'v1 bootstrap could not migrate untracked overlay files'; }
+
+grep -q '/var/tmp/avian-v1-bootstrap.' "$test_root/mktemp.log" \
+  || fail 'v1 bootstrap did not place its verified fetch on persistent storage'
+grep -q '/var/tmp/avian-service-refresh.' "$test_root/mktemp.log" \
+  || fail 'service refresh did not place its verified fetch on persistent storage'
+if find /var/tmp -maxdepth 1 -type d \
+  \( -name 'avian-v1-bootstrap.*' -o -name 'avian-service-refresh.*' \) \
+  -print -quit | grep -q .; then
+  fail 'verified fetch workspace survived a successful v1 handoff'
+fi
 
 [ "$(runuser -u "$collision_user" -- git -C "$collision_repo" branch --show-current)" = avian-visitors ] \
   || fail 'v1 bootstrap did not select the release branch'

--- a/tests/smoke_reinstall_services.sh
+++ b/tests/smoke_reinstall_services.sh
@@ -98,7 +98,20 @@ cat >/usr/local/bin/apt <<'EOF'
 touch /tmp/avian-service-refresh-smoke/apt.called
 exit 99
 EOF
-chmod 0755 /usr/local/bin/systemctl /usr/local/bin/apt
+cat >/usr/local/bin/mktemp <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  case "$argument" in
+    /tmp/avian-service-refresh.*)
+      echo 'large verified fetch attempted to use /tmp' >&2
+      exit 88
+      ;;
+  esac
+done
+printf '%s\n' "$*" >>/tmp/avian-service-refresh-smoke/mktemp.log
+exec /usr/bin/mktemp "$@"
+EOF
+chmod 0755 /usr/local/bin/systemctl /usr/local/bin/apt /usr/local/bin/mktemp
 
 cp /source/scripts/reinstall_services.sh /usr/local/sbin/avian-service-refresh
 chown root:root /usr/local/sbin/avian-service-refresh
@@ -138,6 +151,13 @@ AVIAN_UPDATE_LOCK_FD=9 /usr/local/sbin/avian-service-refresh --legacy-migration 
 flock -u 9
 exec 9>&-
 run_refresh
+
+grep -q '/var/tmp/avian-service-refresh.' "$test_root/mktemp.log" \
+  || fail 'service refresh did not place its verified fetch on persistent storage'
+if find /var/tmp -maxdepth 1 -type d -name 'avian-service-refresh.*' \
+  -print -quit | grep -q .; then
+  fail 'service refresh left its verified fetch workspace behind'
+fi
 
 [ -e "$test_root/security.called" ] || fail 'security policy hook was not called'
 [ ! -e /etc/sudoers.d/010_caddy-nopasswd ] \


### PR DESCRIPTION
Use persistent temporary storage for the bootstrap and service-refresh object stores so Raspberry Pi tmpfs limits cannot truncate the verified release fetch. Remove the bootstrap store before exec and cover both paths with cleanup regressions.