### PR TITLE
[PATCH] atlas and updater follow-up

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Python application
 
 on:
   push:
-    branches: [ "main", "test_me" ]
+    branches: [ "main", "test_me", "avian-visitors" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "avian-visitors" ]
 
 permissions:
   contents: read

--- a/avian/api/generate.php
+++ b/avian/api/generate.php
@@ -29,7 +29,10 @@ $BIRDNETPI_DIR = dirname(__DIR__, 2);
 $ILLUS   = "$BIRDNETPI_DIR/avian/assets/illustrations";
 $STATE   = "$ILLUS/.generate.state.json";
 $STARTS  = "$ILLUS/.generate.starts";
-$LOCK    = "$ILLUS/.generate.lock";
+$LOCK    = getenv('AVIAN_GENERATION_LOCK');
+if (!is_string($LOCK) || $LOCK === '') {
+    $LOCK = '/run/lock/avian-generation.lock';
+}
 $LOG     = "$ILLUS/.generate.log";
 $DB_PATH = "$BIRDNETPI_DIR/scripts/birds.db";
 $CONF    = "$BIRDNETPI_DIR/birdnet.conf";
@@ -226,7 +229,9 @@ if ($action === 'start') {
         echo json_encode(['error' => 'illustration directory unavailable']);
         exit;
     }
-    $generationLock = @fopen($LOCK, 'c');
+    // Provisioned root-owned by the installer. Caddy can lock the inode but
+    // cannot replace it, and the updater shares it for an atomic library view.
+    $generationLock = @fopen($LOCK, 'r+');
     if ($generationLock === false) {
         http_response_code(500);
         echo json_encode(['error' => 'generation lock unavailable']);

--- a/avian/frontend/apt.js
+++ b/avian/frontend/apt.js
@@ -198,6 +198,33 @@
   function readLS(k, fallback) { try { return localStorage.getItem(k) || fallback; } catch (e) { return fallback; } }
   function writeLS(k, v) { try { localStorage.setItem(k, v); } catch (e) { } }
 
+  // Atlas can either follow the shared collage/stats window or stay on the
+  // complete life list. This is a browser preference, like theme and bird
+  // names: it must never enter the Pi config save flow or restart services.
+  var ATLAS_ALWAYS_ALL_KEY = 'bird:atlasAlwaysAll:v1';
+  var sessionAtlasAlwaysAll = null;
+  function atlasAlwaysAll() {
+    if (sessionAtlasAlwaysAll !== null) return sessionAtlasAlwaysAll;
+    return readLS(ATLAS_ALWAYS_ALL_KEY, 'off') === 'on';
+  }
+  function atlasWindowHours() {
+    return atlasAlwaysAll() ? 1000000 : currentHours;
+  }
+  function syncAtlasAlwaysAll() {
+    var on = atlasAlwaysAll();
+    document.querySelectorAll('[data-atlas-always-all]').forEach(function (sw) {
+      sw.setAttribute('aria-checked', on ? 'true' : 'false');
+    });
+    // The all-time life list is already loaded for accession numbers and
+    // totals, so changing this preference needs no second API request.
+    if (DATA && DATA.lifelist) renderAtlas(false);
+  }
+  function applyAtlasAlwaysAll(on) {
+    sessionAtlasAlwaysAll = !!on;
+    writeLS(ATLAS_ALWAYS_ALL_KEY, on ? 'on' : 'off');
+    syncAtlasAlwaysAll();
+  }
+
   // Remember the last confirmed illustration pose independently for each
   // species. Keep a validated in-memory copy so the preference still works
   // for this visit when storage is unavailable (private mode / quota errors).
@@ -321,6 +348,10 @@
     if (ev.key === THEME_KEY || ev.key === LEGACY_THEME_KEY || ev.key === null) {
       sessionThemePreference = null;
       syncTheme();
+    }
+    if (ev.key === ATLAS_ALWAYS_ALL_KEY || ev.key === null) {
+      sessionAtlasAlwaysAll = null;
+      syncAtlasAlwaysAll();
     }
   });
   var winBtns = [].slice.call(winPick.querySelectorAll('button'));
@@ -4370,6 +4401,7 @@
 
     var lifelist = (DATA.lifelist && DATA.lifelist.species) || [];
     var recent = (DATA.recent && DATA.recent.species) || [];
+    var atlasHours = atlasWindowHours();
     // Window count lookup: sci -> count in current window.
     var winBySci = {};
     recent.forEach(function (s) { winBySci[s.sci] = +s.n; });
@@ -4382,7 +4414,7 @@
 
     // Time-window filter: when a windowed view is selected, only show
     // species heard in that window. ALL preserves the full lifelist.
-    var isAllWindow = currentHours >= 1000000;
+    var isAllWindow = atlasHours >= 1000000;
     var filtered = isAllWindow
       ? lifelist
       : lifelist.filter(function (s) { return (winBySci[s.sci] || 0) > 0; });
@@ -4428,7 +4460,7 @@
     // to the life list this 1h / 12h / 24h / 7d. Never shown for the ALL
     // window (every species would qualify against an open-ended span).
     var now = Date.now();
-    var windowStartMs = now - currentHours * 3600000;
+    var windowStartMs = now - atlasHours * 3600000;
 
     var cardHtml = species.map(function (s) {
       var total = +s.n || 0;
@@ -4442,9 +4474,9 @@
       // The "all time" window makes the windowed count identical to the
       // all-time count - collapse to a single stat rather than print the
       // same number twice. Otherwise label the count with its span.
-      var statRows = currentHours >= 1000000
+      var statRows = isAllWindow
         ? '<div><span class="n">' + fmtNK(total) + '</span><span class="lbl-inline">all time</span></div>'
-        : '<div><span class="n">' + fmtNK(win) + '</span><span class="lbl-inline">' + windowLabel(currentHours) + '</span></div>'
+        : '<div><span class="n">' + fmtNK(win) + '</span><span class="lbl-inline">' + windowLabel(atlasHours) + '</span></div>'
         + '<div><span class="n">' + fmtNK(total) + '</span><span class="lbl-inline">all time</span></div>';
       // Heard but never drawn: issue the bird's real family stamp with the
       // egg nest occupying its artwork plate. Waiting on tablesReady keeps
@@ -5550,9 +5582,18 @@
       + '  <div class="seg" data-labels-seg><i class="seg-pill" aria-hidden="true"></i>' + btn('off', 'off') + btn('on', 'on') + '</div>'
       + '</div>';
   }
+  function atlasAlwaysAllRow() {
+    var on = atlasAlwaysAll();
+    return ''
+      + '<div class="menu-row">'
+      + '  <div><span class="label">Always show full atlas</span><span class="hint">show every unlocked stamp</span></div>'
+      + '  <button type="button" class="switch" role="switch" aria-label="Always show full atlas"'
+      + '    aria-checked="' + (on ? 'true' : 'false') + '" data-atlas-always-all></button>'
+      + '</div>';
+  }
   function wireSettingsControls(scope) {
     scope = scope || document;
-    scope.querySelectorAll('.switch').forEach(function (sw) {
+    scope.querySelectorAll('.switch:not([data-atlas-always-all])').forEach(function (sw) {
       sw.addEventListener('click', function () {
         var on = sw.getAttribute('aria-checked') !== 'true';
         sw.setAttribute('aria-checked', on ? 'true' : 'false');
@@ -7063,6 +7104,7 @@
           + '<section>'
           + themeRow()
           + labelsRow()
+          + atlasAlwaysAllRow()
           + '</section><section>'
           + settingsSlider('CONFIDENCE', 'Confidence threshold', 'min score to log a detection', v.CONFIDENCE, 0.1, 0.95, 0.05, 2, 0.7)
           + settingsSlider('SF_THRESH', 'Range filter', 'min likelihood a species is here this week', v.SF_THRESH, 0.001, 0.5, 0.001, 3, 0.03)
@@ -7140,6 +7182,12 @@
           } else {
             labelFontReady = true; renderCollageFromData();
           }
+        });
+        // Atlas-only preference: apply immediately without touching the
+        // shared time picker or sending a station settings request.
+        var atlasAllSwitch = adminBody.querySelector('[data-atlas-always-all]');
+        if (atlasAllSwitch) atlasAllSwitch.addEventListener('click', function () {
+          applyAtlasAlwaysAll(atlasAllSwitch.getAttribute('aria-checked') !== 'true');
         });
       })
       .catch(function (err) {

--- a/avian/frontend/index.html
+++ b/avian/frontend/index.html
@@ -385,6 +385,6 @@ var p=preference();d.setAttribute('data-theme',p==='light'||p==='dark'?p:systemT
 <script src="./stamp-batch-a.js?v=r341"></script>
   <script src="./stamp-batch-b.js?v=r318"></script>
 <script src="./stamp-batch-c.js?v=r234"></script>
-<script src="./apt.js?v=r179"></script>
+<script src="./apt.js?v=r180"></script>
 </body>
 </html>

--- a/avian/frontend/index.html
+++ b/avian/frontend/index.html
@@ -13,7 +13,7 @@
 function systemTheme(){try{return window.matchMedia&&window.matchMedia(q).matches?'dark':'light';}catch(e){return'light';}}
 function preference(){try{var v=localStorage.getItem('bird:theme:v2');if(v==='auto'||v==='light'||v==='dark')return v;var old=localStorage.getItem('bird:theme');return old==='light'||old==='dark'?old:'auto';}catch(e){return'auto';}}
 var p=preference();d.setAttribute('data-theme',p==='light'||p==='dark'?p:systemTheme());})();</script>
-<link rel="stylesheet" href="./styles.css?v=r166">
+<link rel="stylesheet" href="./styles.css?v=r167">
   <link rel="stylesheet" href="./stamps.css?v=r355">
   <link rel="stylesheet" href="./stamp-batch-root.css?v=r254">
   <link rel="stylesheet" href="./stamp-batch-a.css?v=r257">

--- a/avian/frontend/index.html
+++ b/avian/frontend/index.html
@@ -380,7 +380,7 @@ var p=preference();d.setAttribute('data-theme',p==='light'||p==='dark'?p:systemT
   <filter id="waxBirdClean" x="-8%" y="-8%" width="116%" height="116%" color-interpolation-filters="sRGB"><feComponentTransfer><feFuncA type="linear" slope="1.6" intercept="-.28"/></feComponentTransfer></filter>
   <filter id="waxKeyline" x="-30%" y="-22%" width="160%" height="144%" color-interpolation-filters="sRGB"><feComponentTransfer in="SourceAlpha" result="cleanAlpha"><feFuncA type="linear" slope="2.1" intercept="-.55"/></feComponentTransfer><feMorphology in="cleanAlpha" operator="dilate" radius="1.55" result="expanded"/><feFlood flood-color="#eee9de" result="cream"/><feComposite in="cream" in2="expanded" operator="in"/></filter>
 </defs></svg>
-  <script src="./stamps.js?v=r343"></script>
+  <script src="./stamps.js?v=r344"></script>
   <script src="./stamp-batch-root.js?v=r250"></script>
 <script src="./stamp-batch-a.js?v=r341"></script>
   <script src="./stamp-batch-b.js?v=r318"></script>

--- a/avian/frontend/stamps.js
+++ b/avian/frontend/stamps.js
@@ -2261,9 +2261,9 @@ document.documentElement.setAttribute('data-stamps-stage', 'fx-ready');
   }
   TPL_LIST.forEach(function (t) { TPL[t.id] = t; });
 
-  /* ---- genus -> family group. BirdNET reports a binomial, so the genus
-     is enough to place a bird in its group; anything unknown falls back to
-     a stable hash so it still gets a consistent design. ---- */
+  /* ---- genus -> approved family issue. BirdNET reports a binomial, so the
+     genus is enough to place a bird in its reviewed issue. Unknown genera use
+     one deliberate shared issue; they never hash into retired experiments. ---- */
   var GENUS_GROUP = {
     // hummingbirds
     Calypte:'Hummingbirds', Archilochus:'Hummingbirds', Selasphorus:'Hummingbirds',
@@ -2278,14 +2278,19 @@ document.documentElement.setAttribute('data-stamps-stage', 'fx-ready');
     Anas:'Waterfowl', Aix:'Waterfowl', Branta:'Waterfowl', Anser:'Waterfowl',
     Aythya:'Waterfowl', Bucephala:'Waterfowl', Mergus:'Waterfowl',
     Lophodytes:'Waterfowl', Oxyura:'Waterfowl', Cygnus:'Waterfowl', Spatula:'Waterfowl',
+    Mareca:'Waterfowl',
     // owls
     Bubo:'Owls', Tyto:'Owls', Strix:'Owls', Megascops:'Owls', Athene:'Owls', Asio:'Owls',
     // hawks, eagles, falcons, vultures
     Buteo:'Hawks', Accipiter:'Hawks', Haliaeetus:'Hawks', Circus:'Hawks',
     Falco:'Hawks', Cathartes:'Hawks', Elanus:'Hawks', Pandion:'Hawks',
-    // gulls, terns, shorebirds
+    // gulls and terns
     Larus:'Gulls', Chroicocephalus:'Gulls', Sterna:'Gulls', Hydroprogne:'Gulls',
+    // kingfishers
+    Megaceryle:'Kingfishers',
     Charadrius:'Gulls', Actitis:'Gulls', Numenius:'Gulls', Calidris:'Gulls',
+    // sandpipers and allies
+    Tringa:'Shorebirds', Limnodromus:'Shorebirds',
     Himantopus:'Gulls', Recurvirostra:'Gulls', Pelecanus:'Gulls',
     Phalacrocorax:'Gulls', Nannopterum:'Gulls',
     // sparrows and towhees
@@ -2320,13 +2325,17 @@ document.documentElement.setAttribute('data-stamps-stage', 'fx-ready');
     Troglodytes:'Chickadees & Titmice', Thryomanes:'Chickadees & Titmice',
     Catherpes:'Chickadees & Titmice', Regulus:'Chickadees & Titmice',
     Corthylio:'Chickadees & Titmice', Chamaea:'Chickadees & Titmice',
-    // warblers, vireos, tanagers, grosbeaks, swallows, woodpeckers, quail
+    // treecreepers
+    Certhia:'Treecreepers',
+    // swallows
+    Hirundo:'Swallows', Tachycineta:'Swallows', Stelgidopteryx:'Swallows',
+    Petrochelidon:'Swallows',
+    // warblers, vireos, tanagers, grosbeaks, woodpeckers, quail
     Setophaga:'Warblers & Vireos', Geothlypis:'Warblers & Vireos',
     Cardellina:'Warblers & Vireos', Vireo:'Warblers & Vireos',
     Piranga:'Warblers & Vireos', Pheucticus:'Warblers & Vireos',
     Passerina:'Warblers & Vireos', Cardinalis:'Warblers & Vireos',
-    Hirundo:'Warblers & Vireos', Tachycineta:'Warblers & Vireos',
-    Petrochelidon:'Warblers & Vireos', Colaptes:'Warblers & Vireos',
+    Colaptes:'Warblers & Vireos',
     Picoides:'Warblers & Vireos', Dryobates:'Warblers & Vireos',
     Melanerpes:'Warblers & Vireos', Callipepla:'Warblers & Vireos',
     Zenaidura:'Doves & Pigeons'
@@ -2340,12 +2349,14 @@ document.documentElement.setAttribute('data-stamps-stage', 'fx-ready');
     'Doves & Pigeons':'Columbidae', 'Thrushes':'Turdidae', 'Flycatchers':'Tyrannidae',
     'Mockingbirds & Thrashers':'Mimidae', 'Waxwings':'Bombycillidae',
     'Blackbirds & Orioles':'Icteridae', 'Chickadees & Titmice':'Paridae',
-    'Warblers & Vireos':'Parulidae'
+    'Warblers & Vireos':'Parulidae', 'Kingfishers':'Alcedinidae',
+    'Shorebirds':'Scolopacidae', 'Swallows':'Hirundinidae',
+    'Treecreepers':'Certhiidae'
   };
 
   /* ---- One design language per family, so a family reads as one issue.
-     Families without an issue of their own fall back to the field guide,
-     which is the generic look by design rather than by accident. ---- */
+     Families without an issue of their own use the final shared issue,
+     with one approved core issue kept only as its load-failure fallback. ---- */
   var GROUP_STYLE = {
     'Hummingbirds':'geo',                 // low-poly geode
     'Crows & Jays':'mono',                // modernist black
@@ -2365,24 +2376,18 @@ document.documentElement.setAttribute('data-stamps-stage', 'fx-ready');
     'Hawks':'raptor',
     'Warblers & Vireos':'field'
   };
-  var ORDERED_STYLES = ['field','flock','dither','geo','mono','bundespost','zurichpink',
-    'mexico','kieler','linescreen','terraplana','opart','nzplate','editorial','minimal'];
-
   function groupFor(sci) {
     var genus = String(sci || '').split(' ')[0];
     if (GENUS_GROUP[genus]) return GENUS_GROUP[genus];
     return null;
   }
-  function hashPick(str, list) {
-    var h = 0, i;
-    for (i = 0; i < str.length; i++) { h = ((h << 5) - h + str.charCodeAt(i)) | 0; }
-    return list[Math.abs(h) % list.length];
-  }
   function styleFor(sci) {
     var g = groupFor(sci);
     if (g && GROUP_STYLE[g] && TPL[GROUP_STYLE[g]]) return TPL[GROUP_STYLE[g]];
-    // unknown genus: stable per-species pick so it never flickers between renders
-    return TPL[hashPick(String(sci || ''), ORDERED_STYLES)] || TPL.field;
+    // Batch C registers the final shared issue before apt.js renders the Atlas.
+    // If that asset fails, keep the species visible on the approved core geo
+    // issue rather than reviving a retired template or assigning by hash.
+    return TPL.ribbonbird || TPL.geo || null;
   }
   function familyOf(sci) { return groupFor(sci) || 'Other'; }
   function latinOf(sci) {
@@ -2619,10 +2624,14 @@ document.documentElement.setAttribute('data-stamps-stage', 'fx-ready');
 
   /* bird: {sci, com, index, count} -> the stamp's outer HTML */
   function markup(bird, cutoutUrl, template) {
+    if (!bird) return '';
     /* A saved/generated bird may explicitly carry the approved family issue.
        Prefer that over a fresh taxonomy lookup so a cached stamp and its live
        preview can never silently drift into a different design family. */
-    var t = template || (bird.template && TPL[bird.template]) || styleFor(bird.sci);
+    var directTemplate = template && template.id && template.html && template.ar
+      ? template : null;
+    var t = directTemplate || (bird.template && TPL[bird.template]) || styleFor(bird.sci);
+    if (!t) return '';
     var box = boxFor(t.ar);
     var fam = bird.family || familyOf(bird.sci), lat = bird.latin || latinOf(bird.sci);
     var commonParts = splitName(bird.com || bird.sci);

--- a/avian/frontend/styles.css
+++ b/avian/frontend/styles.css
@@ -1541,6 +1541,9 @@ body.postcard-open { overflow: hidden; }
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  /* Line clamp clips exactly at the final line box. Give serif descenders
+     their own ink allowance so g/j/p/q/y are not shaved off at that edge. */
+  padding-block-end: .16em;
   font: 500 clamp(24px, 2.5vw, 34px)/1.08 ui-serif, "Iowan Old Style", Georgia, serif;
   letter-spacing: -.045em;
   text-wrap: balance;

--- a/avian/scripts/generate_one.py
+++ b/avian/scripts/generate_one.py
@@ -19,6 +19,7 @@ Usage:
 """
 from __future__ import annotations
 import argparse
+import fcntl
 import json
 import os
 import subprocess
@@ -37,6 +38,9 @@ ILLUS = HERE.parent / "assets" / "illustrations"
 RAW = ILLUS / "raw"
 CUTS = ILLUS / "cuts.json"
 STATE = ILLUS / ".generate.state.json"
+GENERATION_LOCK = Path(os.environ.get(
+    "AVIAN_GENERATION_LOCK", "/run/lock/avian-generation.lock"
+))
 
 
 def write_state(**kw) -> None:
@@ -136,6 +140,18 @@ def main() -> int:
     key = os.environ.get("GEMINI_API_KEY", "")
     if not key:
         print("error: GEMINI_API_KEY required in the environment", file=sys.stderr)
+        return 2
+
+    # generate.php holds this lock while spawning us. Blocking here is
+    # intentional: the API only waits for a live PID, releases its descriptor,
+    # and then this worker owns the same lock through every PNG/index mutation.
+    # The updater takes the lock only after its separate root update lock, while
+    # generation never takes that update lock, so there is no lock-order cycle.
+    try:
+        generation_lock = GENERATION_LOCK.open("r+")
+        fcntl.flock(generation_lock.fileno(), fcntl.LOCK_EX)
+    except OSError as exc:
+        print(f"error: illustration generation lock unavailable: {exc}", file=sys.stderr)
         return 2
 
     sci, com = args.sci.strip(), args.com.strip()

--- a/scripts/security_refresh.sh
+++ b/scripts/security_refresh.sh
@@ -46,6 +46,19 @@ repo_dir=$birdnet_home/BirdNET-Pi
   || { echo "BirdNET-Pi checkout cannot be a symbolic link" >&2; exit 1; }
 [ -d "$repo_dir/.git" ] || { echo "BirdNET-Pi checkout was not found" >&2; exit 1; }
 
+# Caddy and the station user may lock this inode, but only root can replace it.
+# It serializes asynchronous illustration workers with checkout updates.
+generation_lock=/run/lock/avian-generation.lock
+birdnet_gid=$(id -g "$birdnet_user")
+if [ ! -e "$generation_lock" ] && [ ! -L "$generation_lock" ]; then
+  install -o root -g "$birdnet_gid" -m 0660 /dev/null "$generation_lock"
+fi
+if [ ! -f "$generation_lock" ] || [ -L "$generation_lock" ] \
+  || [ "$(stat -c '%u:%g:%a:%h' "$generation_lock")" != "0:$birdnet_gid:660:1" ]; then
+  echo "Unsafe illustration generation lock: $generation_lock" >&2
+  exit 1
+fi
+
 legacy_state_dir=$repo_dir/scripts
 legacy_state_file=$legacy_state_dir/disk_check_exclude.txt
 if [ ! -d "$legacy_state_dir" ] || [ -L "$legacy_state_dir" ] \

--- a/scripts/update_birdnet.sh
+++ b/scripts/update_birdnet.sh
@@ -12,6 +12,8 @@ readonly RELEASE_BRANCH='avian-visitors'
 readonly CONFIG_FILE='/etc/birdnet/birdnet.conf'
 readonly UPDATE_HELPER='/usr/local/sbin/avian-update-control'
 readonly REFRESH_HELPER='/usr/local/sbin/avian-service-refresh'
+readonly GENERATION_LOCK='/run/lock/avian-generation.lock'
+readonly GENERATION_STALE_SECONDS=900
 
 automatic=false
 
@@ -83,6 +85,8 @@ if [[ ! "$station_home" =~ ^/[A-Za-z0-9._/+@-]+$ ]] \
 fi
 repo_dir=$station_home/BirdNET-Pi
 [ -d "$repo_dir/.git" ] || die 'BirdNET-Pi checkout was not found'
+station_gid=$(id -g "$station_user") \
+  || die 'BirdNET-Pi group could not be resolved'
 
 if [ "$automatic" = true ]; then
   automatic_setting=$(conf_value "$CONFIG_FILE" AUTOMATIC_UPDATE)
@@ -133,6 +137,14 @@ read_git_lines() {
   rm -f "$output"
 }
 
+is_local_bird_art() {
+  [[ "$1" =~ ^avian/assets/(illustrations|cutouts)/[a-z0-9]+(-[a-z0-9]+)*[.]png$ ]]
+}
+
+is_local_illustration() {
+  [[ "$1" =~ ^avian/assets/illustrations/[a-z0-9]+(-[a-z0-9]+)*[.]png$ ]]
+}
+
 # The installed helper is the only process that mutates the checkout. Keep its
 # lock outside station- and web-writable paths.
 lock_file=/run/lock/avian-update.lock
@@ -145,6 +157,44 @@ if [ ! -f "$lock_file" ] || [ -L "$lock_file" ] \
 fi
 exec 9<>"$lock_file"
 flock -n 9 || die 'another update is already running'
+
+# Illustration generation mutates PNGs and their two geometry indexes as one
+# logical library. Keep its lock in /run/lock: the updater runs as root and
+# must not trust a lock inode that Caddy can replace inside the checkout.
+if [ ! -e "$GENERATION_LOCK" ] && [ ! -L "$GENERATION_LOCK" ]; then
+  install -o root -g "$station_gid" -m 0660 /dev/null "$GENERATION_LOCK"
+fi
+if [ ! -f "$GENERATION_LOCK" ] || [ -L "$GENERATION_LOCK" ] \
+  || [ "$(stat -c '%u:%g:%a:%h' "$GENERATION_LOCK")" != "0:$station_gid:660:1" ]; then
+  die "illustration generation lock is unsafe: $GENERATION_LOCK"
+fi
+exec 8<>"$GENERATION_LOCK"
+flock -n 8 || die 'bird illustration generation is running'
+
+# generate.php marks the job running before it releases the start lock and the
+# worker takes that lock for its lifetime. If this process wins that handoff,
+# refuse the fresh state and let the worker acquire the lock when we exit. A
+# stale state is safe here because a genuinely live worker still owns fd 8.
+generation_state=$repo_dir/avian/assets/illustrations/.generate.state.json
+if [ -e "$generation_state" ] || [ -L "$generation_state" ]; then
+  if [ ! -f "$generation_state" ] || [ -L "$generation_state" ]; then
+    die "illustration generation state is unsafe: $generation_state"
+  fi
+  generation_state_json=$(run_as_station head -c 65537 -- "$generation_state") \
+    || die 'illustration generation state could not be read'
+  [ "${#generation_state_json}" -le 65536 ] \
+    || die 'illustration generation state is too large'
+  if [[ "$generation_state_json" =~ \"running\"[[:space:]]*:[[:space:]]*true ]]; then
+    if [[ ! "$generation_state_json" =~ \"at\"[[:space:]]*:[[:space:]]*([0-9]{1,11})([[:space:],}]) ]]; then
+      die 'illustration generation state is invalid'
+    fi
+    generation_started=${BASH_REMATCH[1]}
+    generation_now=$(date +%s)
+    if [ "$generation_started" -gt "$((generation_now - GENERATION_STALE_SECONDS))" ]; then
+      die 'bird illustration generation is starting'
+    fi
+  fi
+fi
 safe_root_helper "$REFRESH_HELPER" \
   || die "root-owned service refresher is missing or unsafe: $REFRESH_HELPER"
 
@@ -220,13 +270,22 @@ read_git_nul staged_paths diff --cached --name-only -z HEAD
 changed_paths=()
 read_git_nul changed_paths diff --name-only -z HEAD
 tracked_generated_paths=()
+tracked_art_paths=()
 untracked_generated_paths=()
 for changed_path in "${changed_paths[@]}"; do
   case "$changed_path" in
     avian/frontend/masks.json|avian/frontend/dims.json)
-      [ -f "$repo_dir/$changed_path" ] \
+      [ -f "$repo_dir/$changed_path" ] && [ ! -L "$repo_dir/$changed_path" ] \
         || die "generated file is missing: $changed_path"
       tracked_generated_paths+=("$changed_path")
+      ;;
+    avian/assets/illustrations/*.png|avian/assets/cutouts/*.png)
+      is_local_bird_art "$changed_path" \
+        || die "tracked file has local changes: $changed_path"
+      if [ ! -f "$repo_dir/$changed_path" ] || [ -L "$repo_dir/$changed_path" ]; then
+        die "custom bird art is missing or unsafe: $changed_path"
+      fi
+      tracked_art_paths+=("$changed_path")
       ;;
     *) die "tracked file has local changes: $changed_path" ;;
   esac
@@ -247,9 +306,13 @@ fi
 backup_dir=''
 generated_archive=''
 collision_archive=''
+art_archive=''
 collision_paths=()
+untracked_art_collision_paths=()
+untracked_illustration_paths=()
 legacy_branch_created=false
 fetch_refspec_changed=false
+transaction_started=false
 transaction_complete=false
 last_archive=''
 
@@ -289,7 +352,8 @@ restore_archive() {
 rollback() {
   local result=$? current_branch current_ref rollback_failed=false worktree_ready=false
   trap - EXIT
-  if [ "$result" -ne 0 ] && [ "$transaction_complete" = false ]; then
+  if [ "$result" -ne 0 ] && [ "$transaction_started" = true ] \
+    && [ "$transaction_complete" = false ]; then
     set +e
     if [ "$original_branch" = "$RELEASE_BRANCH" ]; then
       current_branch=$(git_station symbolic-ref --quiet --short HEAD 2>/dev/null)
@@ -328,14 +392,22 @@ rollback() {
           git_station update-ref -d "refs/heads/$RELEASE_BRANCH" "$current_ref" \
             || rollback_failed=true
         fi
-        if [ -n "$collision_archive" ]; then
-          restore_archive "$collision_archive" >/dev/null 2>&1 \
-            || rollback_failed=true
-        fi
         worktree_ready=true
       else
         rollback_failed=true
       fi
+    fi
+    if [ -n "$collision_archive" ] && [ "$worktree_ready" = true ]; then
+      restore_archive "$collision_archive" >/dev/null 2>&1 \
+        || rollback_failed=true
+    elif [ -n "$collision_archive" ]; then
+      rollback_failed=true
+    fi
+    if [ -n "$art_archive" ] && [ "$worktree_ready" = true ]; then
+      restore_archive "$art_archive" >/dev/null 2>&1 \
+        || rollback_failed=true
+    elif [ -n "$art_archive" ]; then
+      rollback_failed=true
     fi
     if [ -n "$generated_archive" ] && [ "$worktree_ready" = true ]; then
       restore_archive "$generated_archive" >/dev/null 2>&1 \
@@ -362,10 +434,125 @@ rollback() {
 }
 trap rollback EXIT
 
+# Find untracked files that a verified release checkout would need to replace.
+# Ordinary legacy collisions are backed up but yield to the release. Bird art
+# is different: regional bundles and locally generated birds are intentional
+# station data, so exact, safe PNG paths are restored after the checkout.
+untracked_paths=()
+target_paths=()
+read_git_nul untracked_paths ls-files --others -z
+read_git_nul target_paths ls-tree -r --name-only -z "$target_ref"
+declare -A target_files=()
+declare -A target_directories=()
+for target_path in "${target_paths[@]}"; do
+  target_files["$target_path"]=1
+  target_parent=$target_path
+  while [[ "$target_parent" == */* ]]; do
+    target_parent=${target_parent%/*}
+    target_directories["$target_parent"]=1
+  done
+done
+for untracked_path in "${untracked_paths[@]}"; do
+  [[ "$untracked_path" != /* && "$untracked_path" != *$'\n'* \
+    && "/$untracked_path/" != *'/../'* ]] \
+    || die 'an unsafe untracked path blocks migration'
+  if is_local_illustration "$untracked_path"; then
+    if [ ! -f "$repo_dir/$untracked_path" ] || [ -L "$repo_dir/$untracked_path" ]; then
+      die "custom bird art is missing or unsafe: $untracked_path"
+    fi
+    untracked_illustration_paths+=("$untracked_path")
+  fi
+
+  path_collides=false
+  if [[ -n "${target_files[$untracked_path]+present}" \
+    || -n "${target_directories[$untracked_path]+present}" ]]; then
+    path_collides=true
+  else
+    probe=$untracked_path
+    while [[ "$probe" == */* ]]; do
+      probe=${probe%/*}
+      if [[ -n "${target_files[$probe]+present}" ]]; then
+        path_collides=true
+        break
+      fi
+    done
+  fi
+  [ "$path_collides" = true ] || continue
+
+  case "$untracked_path" in
+    avian/frontend/masks.json|avian/frontend/dims.json)
+      # These are archived and removed by the generated-index transaction.
+      ;;
+    avian/assets/illustrations/*.png|avian/assets/cutouts/*.png)
+      if is_local_bird_art "$untracked_path" \
+        && [[ -n "${target_files[$untracked_path]+present}" ]]; then
+        if [ ! -f "$repo_dir/$untracked_path" ] || [ -L "$repo_dir/$untracked_path" ]; then
+          die "custom bird art is missing or unsafe: $untracked_path"
+        fi
+        untracked_art_collision_paths+=("$untracked_path")
+      elif [ "$original_branch" = main ]; then
+        collision_paths+=("$untracked_path")
+      fi
+      ;;
+    *)
+      [ "$original_branch" != main ] || collision_paths+=("$untracked_path")
+      ;;
+  esac
+done
+
+# A custom illustration without matching locally generated geometry would make
+# the collage pack one bitmap using another bitmap's mask. Refuse that silent
+# mismatch. Byte-identical collisions can safely use the release's tables.
+custom_illustrations=()
+for illustration_path in "${tracked_art_paths[@]}" "${untracked_illustration_paths[@]}"; do
+  is_local_illustration "$illustration_path" || continue
+  local_oid=$(git_station hash-object -- "$repo_dir/$illustration_path") \
+    || die "could not inspect custom illustration: $illustration_path"
+  target_oid=''
+  if [[ -n "${target_files[$illustration_path]+present}" ]]; then
+    target_oid=$(git_station rev-parse --verify "$target_ref:$illustration_path") \
+      || die "could not inspect release illustration: $illustration_path"
+  fi
+  [ "$local_oid" = "$target_oid" ] || custom_illustrations+=("$illustration_path")
+done
+
+if [ "${#custom_illustrations[@]}" -gt 0 ]; then
+  for generated_path in avian/frontend/masks.json avian/frontend/dims.json; do
+    if [ ! -f "$repo_dir/$generated_path" ] || [ -L "$repo_dir/$generated_path" ]; then
+      die 'custom illustrations require local masks.json and dims.json; rebuild both before updating'
+    fi
+    generated_already_listed=false
+    for listed_path in "${tracked_generated_paths[@]}" "${untracked_generated_paths[@]}"; do
+      if [ "$listed_path" = "$generated_path" ]; then
+        generated_already_listed=true
+        break
+      fi
+    done
+    if [ "$generated_already_listed" = false ]; then
+      if git_station ls-files --error-unmatch -- "$generated_path" >/dev/null 2>&1; then
+        tracked_generated_paths+=("$generated_path")
+      else
+        untracked_generated_paths+=("$generated_path")
+      fi
+    fi
+  done
+  for illustration_path in "${custom_illustrations[@]}"; do
+    illustration_slug=${illustration_path##*/}
+    illustration_slug=${illustration_slug%.png}
+    run_as_station grep -Eq \
+      "\"$illustration_slug\"[[:space:]]*:" "$repo_dir/avian/frontend/masks.json" \
+      || die "masks.json is missing custom illustration: $illustration_slug"
+    run_as_station grep -Eq \
+      "\"$illustration_slug\"[[:space:]]*:" "$repo_dir/avian/frontend/dims.json" \
+      || die "dims.json is missing custom illustration: $illustration_slug"
+  done
+fi
+
 generated_paths=("${tracked_generated_paths[@]}" "${untracked_generated_paths[@]}")
 if [ "${#generated_paths[@]}" -gt 0 ]; then
   archive_paths generated "${generated_paths[@]}"
   generated_archive=$last_archive
+  transaction_started=true
   if [ "${#tracked_generated_paths[@]}" -gt 0 ]; then
     git_station restore --worktree -- "${tracked_generated_paths[@]}"
   fi
@@ -374,10 +561,33 @@ if [ "${#generated_paths[@]}" -gt 0 ]; then
   done
 fi
 
+preserved_art_paths=("${tracked_art_paths[@]}" "${untracked_art_collision_paths[@]}")
+if [ "${#preserved_art_paths[@]}" -gt 0 ]; then
+  archive_paths custom-bird-art "${preserved_art_paths[@]}"
+  art_archive=$last_archive
+  transaction_started=true
+  if [ "${#tracked_art_paths[@]}" -gt 0 ]; then
+    git_station restore --worktree -- "${tracked_art_paths[@]}"
+  fi
+  for art_path in "${untracked_art_collision_paths[@]}"; do
+    run_as_station rm -f -- "$repo_dir/$art_path"
+  done
+fi
+
+if [ "${#collision_paths[@]}" -gt 0 ]; then
+  archive_paths legacy-collisions "${collision_paths[@]}"
+  collision_archive=$last_archive
+  transaction_started=true
+  for collision_path in "${collision_paths[@]}"; do
+    run_as_station rm -f -- "$repo_dir/$collision_path"
+  done
+fi
+
 if [ "$original_branch" = "$RELEASE_BRANCH" ]; then
   git_station merge-base --is-ancestor "$original_head" "$target_commit" \
     || die "local $RELEASE_BRANCH has commits not present on origin"
   if [ "$original_head" != "$target_commit" ]; then
+    transaction_started=true
     git_station merge --ff-only "$target_ref"
   fi
 else
@@ -391,50 +601,11 @@ else
       || die "local $RELEASE_BRANCH has diverged from origin"
   fi
 
-  untracked_paths=()
-  target_paths=()
-  read_git_nul untracked_paths ls-files --others -z
-  read_git_nul target_paths ls-tree -r --name-only -z "$target_ref"
-  declare -A target_files=()
-  declare -A target_directories=()
-  for target_path in "${target_paths[@]}"; do
-    target_files["$target_path"]=1
-    target_parent=$target_path
-    while [[ "$target_parent" == */* ]]; do
-      target_parent=${target_parent%/*}
-      target_directories["$target_parent"]=1
-    done
-  done
-  for untracked_path in "${untracked_paths[@]}"; do
-    [[ "$untracked_path" != /* && "$untracked_path" != *$'\n'* \
-      && "/$untracked_path/" != *'/../'* ]] \
-      || die 'an unsafe untracked path blocks migration'
-    if [[ -n "${target_files[$untracked_path]+present}" \
-      || -n "${target_directories[$untracked_path]+present}" ]]; then
-      collision_paths+=("$untracked_path")
-      continue
-    fi
-    probe=$untracked_path
-    while [[ "$probe" == */* ]]; do
-      probe=${probe%/*}
-      if [[ -n "${target_files[$probe]+present}" ]]; then
-        collision_paths+=("$untracked_path")
-        break
-      fi
-    done
-  done
-
-  if [ "${#collision_paths[@]}" -gt 0 ]; then
-    archive_paths legacy-collisions "${collision_paths[@]}"
-    collision_archive=$last_archive
-    for collision_path in "${collision_paths[@]}"; do
-      run_as_station rm -f -- "$repo_dir/$collision_path"
-    done
-  fi
-
   if git_station show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+    transaction_started=true
     git_station switch "$RELEASE_BRANCH"
   else
+    transaction_started=true
     git_station switch --create "$RELEASE_BRANCH"
     legacy_branch_created=true
   fi
@@ -444,6 +615,7 @@ fi
 # Depth-limited legacy clones normally fetch only main. Replace every inherited
 # mapping with the exact release mapping before recording the new upstream.
 release_fetch_refspec="+refs/heads/$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH"
+transaction_started=true
 git_station config --replace-all remote.origin.fetch "$release_fetch_refspec" \
   || die 'could not configure the release fetch mapping'
 fetch_refspec_changed=true
@@ -451,6 +623,9 @@ git_station branch --set-upstream-to="origin/$RELEASE_BRANCH" "$RELEASE_BRANCH" 
 
 if [ -n "$generated_archive" ]; then
   restore_archive "$generated_archive"
+fi
+if [ -n "$art_archive" ]; then
+  restore_archive "$art_archive"
 fi
 transaction_complete=true
 
@@ -462,6 +637,9 @@ else
 fi
 if [ -n "$collision_archive" ]; then
   printf 'Legacy file backup: %s\n' "$backup_dir"
+fi
+if [ -n "$art_archive" ]; then
+  printf 'Preserved custom bird art: %s\n' "$backup_dir"
 fi
 
 safe_root_helper "$REFRESH_HELPER" \

--- a/tests/smoke_atlas_always_all.mjs
+++ b/tests/smoke_atlas_always_all.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const source = fs.readFileSync(new URL('../avian/frontend/apt.js', import.meta.url), 'utf8');
+
+function functionSource(name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} is present`);
+  const body = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = body; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}' && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`${name} has no closing brace`);
+}
+
+const store = new Map();
+const writes = [];
+let syncCount = 0;
+const context = {
+  currentHours: 24,
+  readLS(key, fallback) { return store.get(key) || fallback; },
+  writeLS(key, value) { store.set(key, value); writes.push([key, value]); },
+  syncAtlasAlwaysAll() { syncCount += 1; },
+};
+vm.createContext(context);
+vm.runInContext(`
+  var ATLAS_ALWAYS_ALL_KEY = 'bird:atlasAlwaysAll:v1';
+  var sessionAtlasAlwaysAll = null;
+  ${functionSource('atlasAlwaysAll')}
+  ${functionSource('atlasWindowHours')}
+  ${functionSource('applyAtlasAlwaysAll')}
+  this.preference = { atlasAlwaysAll, atlasWindowHours, applyAtlasAlwaysAll };
+`, context);
+
+assert.equal(context.preference.atlasAlwaysAll(), false, 'fresh browsers follow the shared window');
+assert.equal(context.preference.atlasWindowHours(), 24, 'default preserves the current 24-hour Atlas');
+
+store.set('bird:atlasAlwaysAll:v1', 'on');
+vm.runInContext('sessionAtlasAlwaysAll = null', context);
+assert.equal(context.preference.atlasAlwaysAll(), true, 'saved on preference restores');
+assert.equal(context.preference.atlasWindowHours(), 1000000, 'on resolves Atlas to ALL');
+
+store.set('bird:atlasAlwaysAll:v1', 'unexpected');
+vm.runInContext('sessionAtlasAlwaysAll = null', context);
+context.currentHours = 168;
+assert.equal(context.preference.atlasAlwaysAll(), false, 'invalid storage fails closed');
+assert.equal(context.preference.atlasWindowHours(), 168, 'invalid storage leaves the shared window alone');
+
+context.preference.applyAtlasAlwaysAll(true);
+assert.deepEqual(writes.at(-1), ['bird:atlasAlwaysAll:v1', 'on'], 'toggle persists on');
+assert.equal(context.preference.atlasWindowHours(), 1000000, 'toggle applies immediately');
+context.preference.applyAtlasAlwaysAll(false);
+assert.deepEqual(writes.at(-1), ['bird:atlasAlwaysAll:v1', 'off'], 'toggle persists off');
+assert.equal(context.preference.atlasWindowHours(), 168, 'turning it off restores, not replaces, the shared window');
+assert.equal(syncCount, 2, 'each toggle performs one Atlas-only sync');
+
+const renderStart = source.indexOf('function renderAtlas(');
+const renderEnd = source.indexOf('\n  var atlasResizeFrame', renderStart);
+const renderAtlas = source.slice(renderStart, renderEnd);
+assert.match(renderAtlas, /var atlasHours = atlasWindowHours\(\)/, 'Atlas resolves its own effective window');
+assert.doesNotMatch(renderAtlas, /currentHours/, 'Atlas rendering no longer reads the shared window directly');
+assert.match(renderAtlas, /var isAllWindow = atlasHours >= 1000000/, 'ALL controls filtering');
+assert.match(renderAtlas, /var statRows = isAllWindow/, 'ALL controls card count copy');
+
+assert.match(source, /Always show full atlas/, 'Settings copy is present');
+assert.match(source, /show every unlocked stamp/, 'Settings explains the result');
+assert.match(source, /\.switch:not\(\[data-atlas-always-all\]\)/,
+  'client preference is excluded from Pi config autosave');
+assert.match(source, /var forHours = currentHours;/, 'collage and stats requests still use the shared window');
+
+console.log('atlas always-all smoke: ok');

--- a/tests/smoke_generate_api.sh
+++ b/tests/smoke_generate_api.sh
@@ -9,6 +9,8 @@ fail() {
   exit 1
 }
 
+command -v flock >/dev/null 2>&1 || fail "flock is required for this smoke test"
+
 work=$(mktemp -d "${TMPDIR:-/tmp}/avian-generate-test.XXXXXX")
 fixture="$work/station"
 worker_log="$work/workers.log"
@@ -51,6 +53,8 @@ SQL
 
 cat >"$fixture/birdnet/bin/python3" <<'SH'
 #!/bin/sh
+exec 7<>"$AVIAN_GENERATION_LOCK"
+flock 7
 printf '%s\n' "$*" >>"$FAKE_WORKER_LOG"
 sleep 2
 SH
@@ -107,6 +111,7 @@ FAKE_WORKER_LOG="$worker_log" \
 FAKE_NOHUP_ARGV="$nohup_argv" \
 FAKE_NOHUP_ENV="$nohup_env" \
 FAKE_PS_SNAPSHOT="$ps_snapshot" \
+AVIAN_GENERATION_LOCK="$fixture/avian/assets/illustrations/.generate.lock" \
 PHP_CLI_SERVER_WORKERS=8 \
   php -d "auto_prepend_file=$work/sqlite-prepend.php" \
   -S "127.0.0.1:$port" -t "$fixture" >"$server_log" 2>&1 &
@@ -242,6 +247,9 @@ done
 [ -s "$worker_log" ] || fail "accepted request did not start a worker"
 [ "$(wc -l <"$worker_log" | tr -d ' ')" -eq 1 ] \
   || fail "parallel requests started more than one worker"
+if flock -n "$lock" true; then
+  fail "spawned worker did not retain the generation lock"
+fi
 [ "$(wc -l <"$fixture/avian/assets/illustrations/.generate.starts" | tr -d ' ')" -eq 1 ] \
   || fail "parallel requests recorded more than one start"
 php -r '

--- a/tests/smoke_pre_v1_bootstrap.sh
+++ b/tests/smoke_pre_v1_bootstrap.sh
@@ -26,7 +26,8 @@ old_release=4515065dd38a3f5e4c244398d30a6f872384cb87
 
 rm -rf "$test_root" "$station_home"
 mkdir -p "$seed/scripts" "$seed/avian/frontend/fonts" \
-  "$seed/avian/frontend/assets" "$seed/avian/assets" "$webroot" \
+  "$seed/avian/frontend/assets" "$seed/avian/assets/illustrations" \
+  "$seed/avian/assets/cutouts" "$webroot" \
   /etc/birdnet /etc/sudoers.d /usr/local/bin /usr/local/sbin
 id "$station_user" >/dev/null 2>&1 \
   || useradd -M -d "$station_home" -s /bin/bash "$station_user"
@@ -67,6 +68,11 @@ for frontend_file in \
   stamp-batch-c.css stamp-batch-c.js grain.png stats-press.png; do
   printf '%s\n' "$frontend_file" >"$seed/avian/frontend/$frontend_file"
 done
+printf '{"shared-bird":{"w":1,"h":1,"bits":"AA=="}}\n' \
+  >"$seed/avian/frontend/masks.json"
+printf '{"shared-bird":[1,1]}\n' >"$seed/avian/frontend/dims.json"
+printf 'official shared bird\n' \
+  >"$seed/avian/assets/illustrations/shared-bird.png"
 printf 'fixture\n' >"$seed/avian/frontend/fonts/.keep"
 printf 'fixture\n' >"$seed/avian/frontend/assets/.keep"
 printf 'favicon\n' >"$seed/avian/assets/favicon.png"
@@ -175,6 +181,7 @@ collision_home=/home/$collision_user
 collision_repo=$collision_home/BirdNET-Pi
 collision_webroot=$collision_home/BirdSongs/Extracted
 rm -rf "$collision_home"
+rm -f /run/lock/avian-generation.lock
 id "$collision_user" >/dev/null 2>&1 \
   || useradd -M -d "$collision_home" -s /bin/bash "$collision_user"
 mkdir -p "$collision_home"
@@ -185,10 +192,16 @@ runuser -u "$collision_user" -- env HOME="$collision_home" \
   git -C "$collision_repo" remote set-url origin "$official"
 runuser -u "$collision_user" -- env HOME="$collision_home" \
   git -C "$collision_repo" switch -q main
-mkdir -p "$collision_repo/avian/frontend" "$collision_repo/custom" "$collision_webroot"
+mkdir -p "$collision_repo/avian/frontend" \
+  "$collision_repo/avian/assets/illustrations" \
+  "$collision_repo/custom" "$collision_webroot"
 printf 'legacy page\n' >"$collision_repo/avian/frontend/index.html"
-printf 'legacy masks\n' >"$collision_repo/avian/frontend/masks.json"
-printf 'legacy dims\n' >"$collision_repo/avian/frontend/dims.json"
+printf '{"shared-bird":{"w":2,"h":2,"bits":"AA=="}}\n' \
+  >"$collision_repo/avian/frontend/masks.json"
+printf '{"shared-bird":[2,2]}\n' \
+  >"$collision_repo/avian/frontend/dims.json"
+printf 'local regional shared bird\n' \
+  >"$collision_repo/avian/assets/illustrations/shared-bird.png"
 printf 'keep local\n' >"$collision_repo/avian/frontend/local-note.txt"
 printf 'keep outside\n' >"$collision_repo/custom/notes.txt"
 chown -R "$collision_user:$collision_user" "$collision_home"
@@ -220,10 +233,13 @@ fi
   || fail 'v1 bootstrap did not reach the release commit'
 grep -qx index.html "$collision_repo/avian/frontend/index.html" \
   || fail 'release page did not replace its legacy collision'
-grep -qx 'legacy masks' "$collision_repo/avian/frontend/masks.json" \
+grep -q '"shared-bird"' "$collision_repo/avian/frontend/masks.json" \
   || fail 'v1 bootstrap did not preserve legacy masks'
-grep -qx 'legacy dims' "$collision_repo/avian/frontend/dims.json" \
+grep -q '"shared-bird"' "$collision_repo/avian/frontend/dims.json" \
   || fail 'v1 bootstrap did not preserve legacy dimensions'
+grep -qx 'local regional shared bird' \
+  "$collision_repo/avian/assets/illustrations/shared-bird.png" \
+  || fail 'v1 bootstrap did not preserve a regional illustration collision'
 grep -qx 'keep local' "$collision_repo/avian/frontend/local-note.txt" \
   || fail 'v1 bootstrap removed a nested noncollision'
 grep -qx 'keep outside' "$collision_repo/custom/notes.txt" \

--- a/tests/smoke_stamp_issues.sh
+++ b/tests/smoke_stamp_issues.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+node - "$repo" <<'NODE'
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const repo = process.argv[2];
+const frontend = path.join(repo, 'avian/frontend');
+const document = {
+  documentElement: { setAttribute() {} },
+  createElement() {
+    return {
+      style: {}, setAttribute() {}, appendChild() {},
+      querySelectorAll() { return []; }
+    };
+  },
+  querySelector() { return null; },
+  querySelectorAll() { return []; },
+  body: { appendChild() {} }
+};
+const window = {
+  addEventListener() {},
+  matchMedia() { return { matches: false }; },
+  document,
+  devicePixelRatio: 1
+};
+const sandbox = {
+  window, document, globalThis: null,
+  Image: function Image() {},
+  IntersectionObserver: undefined,
+  ResizeObserver: undefined,
+  requestAnimationFrame() {},
+  setTimeout() { return 1; },
+  clearTimeout() {},
+  getComputedStyle() { return { getPropertyValue() { return ''; } }; },
+  innerHeight: 800,
+  console, Promise, Math, Uint8Array, Uint16Array, Uint32Array, Int32Array,
+  Float32Array, Map, Set
+};
+sandbox.globalThis = sandbox;
+
+[
+  'stamps.js',
+  'stamp-batch-root.js',
+  'stamp-batch-a.js',
+  'stamp-batch-b.js',
+  'stamp-batch-c.js'
+].forEach((file) => {
+  vm.runInNewContext(fs.readFileSync(path.join(frontend, file), 'utf8'), sandbox, {
+    filename: file
+  });
+});
+
+const stamps = window.STAMPS;
+const stampSource = fs.readFileSync(path.join(frontend, 'stamps.js'), 'utf8');
+assert.doesNotMatch(stampSource, /ORDERED_STYLES|hashPick/,
+  'unsupported names must not retain the legacy template hash path');
+[
+  ['Megaceryle alcyon', 'Kingfishers', 'ribbonbird'],
+  ['Mareca strepera', 'Waterfowl', 'linescreen'],
+  ['Stelgidopteryx serripennis', 'Swallows', 'ribbonbird'],
+  ['Certhia americana', 'Treecreepers', 'ribbonbird'],
+  ['Tringa melanoleuca', 'Shorebirds', 'ribbonbird'],
+  ['Limnodromus scolopaceus', 'Shorebirds', 'ribbonbird']
+].forEach(([sci, family, style]) => {
+  assert.equal(stamps.familyOf(sci), family, `${sci} family`);
+  assert.equal(stamps.styleFor(sci).id, style, `${sci} style`);
+});
+
+[
+  ['Megaceryle alcyon', 'Alcedinidae'],
+  ['Stelgidopteryx serripennis', 'Hirundinidae'],
+  ['Certhia americana', 'Certhiidae'],
+  ['Tringa melanoleuca', 'Scolopacidae'],
+  ['Limnodromus scolopaceus', 'Scolopacidae']
+].forEach(([sci, latin]) => {
+  assert.equal(stamps.latinOf(sci), latin, `${sci} Latin family`);
+});
+
+const future = 'Futuregenus example';
+assert.equal(stamps.familyOf(future), 'Other', 'unknown genera remain Other');
+assert.equal(stamps.latinOf(future), '', 'unknown genera have no false Latin family');
+assert.equal(stamps.styleFor(future).id, 'ribbonbird', 'unknown genera use ribbonbird');
+const futureMarkup = stamps.markup({ sci: future, com: 'Future Bird', index: 1 }, './bird.png');
+assert.match(futureMarkup, /data-family="Other"/);
+assert.match(futureMarkup, /data-style="ribbonbird"/);
+
+[
+  'Unknownus alpha', 'Unknownus beta', 'Novelgenus gamma',
+  'Anothergenus delta', 'Uncatalogued epsilon'
+].forEach((sci) => {
+  assert.equal(stamps.styleFor(sci).id, 'ribbonbird',
+    `${sci} must not hash into a retired template`);
+});
+
+const fallback = stamps.TPL.ribbonbird;
+delete stamps.TPL.ribbonbird;
+assert.equal(stamps.styleFor(future).id, 'geo',
+  'missing shared issue keeps the species on an approved core issue');
+assert.match(stamps.markup({ sci: future, com: 'Future Bird', index: 1 }, './bird.png'),
+  /data-style="geo"/, 'missing shared issue still emits a complete stamp');
+const explicitMarkup = stamps.markup(
+  { sci: future, com: 'Future Bird', index: 1 }, './bird.png', stamps.TPL.geo
+);
+assert.match(explicitMarkup, /data-family="Other"/);
+assert.match(explicitMarkup, /data-style="geo"/);
+stamps.TPL.ribbonbird = fallback;
+NODE
+
+printf '%s\n' 'stamp issue smoke test passed'

--- a/tests/smoke_update.sh
+++ b/tests/smoke_update.sh
@@ -51,10 +51,16 @@ git -C "$seed" add .
 git -C "$seed" commit -qm base
 
 git -C "$seed" switch -qc avian-visitors
-mkdir -p "$seed/avian/frontend"
+mkdir -p "$seed/avian/frontend" "$seed/avian/assets/illustrations" \
+  "$seed/avian/assets/cutouts"
 printf 'one\n' >"$seed/version.txt"
-printf 'mask-one\n' >"$seed/avian/frontend/masks.json"
-printf 'dims-one\n' >"$seed/avian/frontend/dims.json"
+printf '{"shared-bird":{"w":1,"h":1,"bits":"AA=="},"identical-bird":{"w":1,"h":1,"bits":"AA=="}}\n' \
+  >"$seed/avian/frontend/masks.json"
+printf '{"shared-bird":[1,1],"identical-bird":[1,1]}\n' \
+  >"$seed/avian/frontend/dims.json"
+printf 'official shared art\n' >"$seed/avian/assets/illustrations/shared-bird.png"
+printf 'official identical art\n' >"$seed/avian/assets/illustrations/identical-bird.png"
+printf 'official shared cutout\n' >"$seed/avian/assets/cutouts/shared-photo.png"
 printf 'official collision\n' >"$seed/avian/legacy.txt"
 printf 'fail-filter.txt filter=fail\n' >"$seed/.gitattributes"
 printf 'filter content\n' >"$seed/fail-filter.txt"
@@ -65,8 +71,19 @@ printf 'two\n' >"$seed/version.txt"
 git -C "$seed" add version.txt
 git -C "$seed" commit -qm release-two
 release_two=$(git -C "$seed" rev-parse HEAD)
+printf 'three\n' >"$seed/version.txt"
+printf 'release-three shared art\n' >"$seed/avian/assets/illustrations/shared-bird.png"
+printf 'release-three Swiss collision\n' >"$seed/avian/assets/illustrations/swiss-only.png"
+printf '{"shared-bird":{"w":1,"h":1,"bits":"AA=="},"identical-bird":{"w":1,"h":1,"bits":"AA=="},"swiss-only":{"w":1,"h":1,"bits":"AA=="}}\n' \
+  >"$seed/avian/frontend/masks.json"
+printf '{"shared-bird":[1,1],"identical-bird":[1,1],"swiss-only":[1,1]}\n' \
+  >"$seed/avian/frontend/dims.json"
+git -C "$seed" add .
+git -C "$seed" commit -qm release-three
+release_three=$(git -C "$seed" rev-parse HEAD)
 
 git clone -q --bare "$seed" "$remote"
+git -C "$remote" update-ref refs/heads/avian-visitors "$release_two"
 git -C "$remote" symbolic-ref HEAD refs/heads/main
 git clone -q --bare "$seed" "$missing_remote"
 git -C "$missing_remote" update-ref -d refs/heads/avian-visitors
@@ -86,6 +103,7 @@ setup_case() {
   station_home=$test_root/$name/home
   repo_dir=$station_home/BirdNET-Pi
   case_log=$test_root/$name.log
+  rm -f /run/lock/avian-generation.lock
   id "$station_user" >/dev/null 2>&1 \
     || useradd -M -d "$station_home" -s /bin/bash "$station_user"
   mkdir -p "$station_home"
@@ -219,6 +237,56 @@ grep -q 'another update is already running' "$case_log" \
 flock -u 8
 exec 8>&-
 
+setup_case generating release-one
+generation_lock=/run/lock/avian-generation.lock
+install -o root -g "$(id -g "$station_user")" -m 0660 /dev/null "$generation_lock"
+generation_ready=$station_home/generation.ready
+rm -f "$generation_ready"
+as_station "$station_user" "$station_home" \
+  flock "$generation_lock" sh -c "touch '$generation_ready'; sleep 10" &
+generation_pid=$!
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -e "$generation_ready" ] && break
+  sleep 0.1
+done
+[ -e "$generation_ready" ] || fail 'could not hold the generation lock'
+expect_failure 'active illustration generation'
+grep -q 'bird illustration generation is running' "$case_log" \
+  || fail 'generation-lock error was unclear'
+kill "$generation_pid" 2>/dev/null || true
+wait "$generation_pid" 2>/dev/null || true
+
+setup_case generationhandoff release-one
+install -o root -g "$(id -g "$station_user")" -m 0660 /dev/null "$generation_lock"
+printf '{"running":true,"at":%s}\n' "$(date +%s)" \
+  >"$repo_dir/avian/assets/illustrations/.generate.state.json"
+chown "$station_user:$station_user" \
+  "$repo_dir/avian/assets/illustrations/.generate.state.json"
+expect_failure 'illustration worker handoff'
+grep -q 'bird illustration generation is starting' "$case_log" \
+  || fail 'generation-handoff error was unclear'
+printf '{"running":true,"at":1}\n' \
+  >"$repo_dir/avian/assets/illustrations/.generate.state.json"
+expect_success 'stale generation handoff'
+
+setup_case unsafegenerationlock release-one
+ln -s /etc/passwd /run/lock/avian-generation.lock
+expect_failure 'unsafe illustration generation lock'
+grep -q 'illustration generation lock is unsafe' "$case_log" \
+  || fail 'unsafe generation-lock error was unclear'
+rm -f /run/lock/avian-generation.lock
+
+setup_case hardlinkedgenerationlock release-one
+generation_lock_peer=/run/lock/avian-generation-lock-peer
+rm -f "$generation_lock_peer"
+install -o root -g "$(id -g "$station_user")" -m 0660 /dev/null \
+  "$generation_lock_peer"
+ln "$generation_lock_peer" /run/lock/avian-generation.lock
+expect_failure 'hard-linked illustration generation lock'
+grep -q 'illustration generation lock is unsafe' "$case_log" \
+  || fail 'hard-linked generation-lock error was unclear'
+rm -f /run/lock/avian-generation.lock "$generation_lock_peer"
+
 setup_case missinghelper release-one
 cp /usr/local/sbin/avian-service-refresh "$test_root/service-refresh.saved"
 rm -f /usr/local/sbin/avian-service-refresh
@@ -314,9 +382,39 @@ cat >/etc/gitconfig <<EOF
 EOF
 expect_failure 'fetch failure'
 
+setup_case badartindexes release-one
+printf 'preflight must preserve this art\n' \
+  >"$repo_dir/avian/assets/illustrations/shared-bird.png"
+printf '{"different-bird":{"w":2,"h":2,"bits":"AA=="}}\n' \
+  >"$repo_dir/avian/frontend/masks.json"
+printf '{"different-bird":[2,2]}\n' >"$repo_dir/avian/frontend/dims.json"
+chown "$station_user:$station_user" \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  "$repo_dir/avian/frontend/masks.json" "$repo_dir/avian/frontend/dims.json"
+bad_indexes_head=$(as_station "$station_user" "$station_home" \
+  git -C "$repo_dir" rev-parse HEAD)
+expect_failure 'custom illustration with stale generated indexes'
+grep -q 'masks.json is missing custom illustration: shared-bird' "$case_log" \
+  || fail 'stale custom-index error was unclear'
+[ "$(as_station "$station_user" "$station_home" git -C "$repo_dir" rev-parse HEAD)" \
+  = "$bad_indexes_head" ] \
+  || fail 'custom-index preflight failure moved HEAD'
+grep -qx 'preflight must preserve this art' \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  || fail 'custom-index preflight failure changed local art'
+grep -q '"different-bird"' "$repo_dir/avian/frontend/masks.json" \
+  || fail 'custom-index preflight failure changed masks.json'
+grep -q '"different-bird"' "$repo_dir/avian/frontend/dims.json" \
+  || fail 'custom-index preflight failure changed dims.json'
+
 setup_case standardrollback release-one
-printf 'rollback masks\n' >"$repo_dir/avian/frontend/masks.json"
-chown "$station_user:$station_user" "$repo_dir/avian/frontend/masks.json"
+printf '{"shared-bird":{"w":2,"h":2,"bits":"AA=="}}\n' \
+  >"$repo_dir/avian/frontend/masks.json"
+printf '{"shared-bird":[2,2]}\n' >"$repo_dir/avian/frontend/dims.json"
+printf 'rollback custom art\n' >"$repo_dir/avian/assets/illustrations/shared-bird.png"
+chown "$station_user:$station_user" \
+  "$repo_dir/avian/frontend/masks.json" "$repo_dir/avian/frontend/dims.json" \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png"
 cat >"$repo_dir/.git/hooks/post-merge" <<EOF
 #!/usr/bin/env bash
 touch "$repo_dir/.git/config.lock"
@@ -329,8 +427,13 @@ rm -f "$repo_dir/.git/config.lock"
   || fail 'failed release update did not restore its branch ref'
 grep -qx 'one' "$repo_dir/version.txt" \
   || fail 'failed release update did not restore its worktree'
-grep -qx 'rollback masks' "$repo_dir/avian/frontend/masks.json" \
+grep -q '"shared-bird"' "$repo_dir/avian/frontend/masks.json" \
   || fail 'failed release update did not restore generated data'
+grep -q '"shared-bird"' "$repo_dir/avian/frontend/dims.json" \
+  || fail 'failed release update did not restore generated dimensions'
+grep -qx 'rollback custom art' \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  || fail 'failed release update did not restore custom bird art'
 
 setup_case repair release-one
 touch "$test_root/refresh.fail"
@@ -344,11 +447,50 @@ grep -q 'Already up to date.' "$case_log" \
 [ -e "$test_root/refresh.called" ] \
   || fail 'up-to-date rerun did not repair services'
 
+setup_case artwithoutindexes main
+mkdir -p "$repo_dir/avian/assets/illustrations"
+printf 'local Swiss art\n' >"$repo_dir/avian/assets/illustrations/shared-bird.png"
+chown -R "$station_user:$station_user" "$repo_dir/avian"
+expect_failure 'custom illustration without generated indexes'
+grep -q 'custom illustrations require local masks.json and dims.json' "$case_log" \
+  || fail 'missing custom-index error was unclear'
+[ "$(as_station "$station_user" "$station_home" \
+  git -C "$repo_dir" branch --show-current)" = main ] \
+  || fail 'custom-index refusal switched branches'
+grep -qx 'local Swiss art' "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  || fail 'custom-index refusal changed local art'
+
+setup_case identicalart main
+mkdir -p "$repo_dir/avian/assets/illustrations"
+printf 'official identical art\n' \
+  >"$repo_dir/avian/assets/illustrations/identical-bird.png"
+chown -R "$station_user:$station_user" "$repo_dir/avian"
+expect_success 'byte-identical illustration collision'
+[ "$(as_station "$station_user" "$station_home" \
+  git -C "$repo_dir" branch --show-current)" = avian-visitors ] \
+  || fail 'byte-identical collision did not migrate'
+as_station "$station_user" "$station_home" git -C "$repo_dir" diff --quiet -- \
+  avian/assets/illustrations/identical-bird.png \
+  || fail 'byte-identical collision became a dirty override'
+
 setup_case legacy main
-mkdir -p "$repo_dir/avian/frontend" "$repo_dir/custom"
+mkdir -p "$repo_dir/avian/frontend" "$repo_dir/avian/assets/illustrations" \
+  "$repo_dir/avian/assets/cutouts" "$repo_dir/custom"
 printf 'legacy local copy\n' >"$repo_dir/avian/legacy.txt"
-printf 'legacy masks\n' >"$repo_dir/avian/frontend/masks.json"
-printf 'legacy dims\n' >"$repo_dir/avian/frontend/dims.json"
+printf '{"shared-bird":{"w":2,"h":2,"bits":"AA=="},"identical-bird":{"w":1,"h":1,"bits":"AA=="},"swiss-only":{"w":2,"h":2,"bits":"AA=="}}\n' \
+  >"$repo_dir/avian/frontend/masks.json"
+printf '{"shared-bird":[2,2],"identical-bird":[1,1],"swiss-only":[2,2]}\n' \
+  >"$repo_dir/avian/frontend/dims.json"
+printf 'local Swiss shared art\n' \
+  >"$repo_dir/avian/assets/illustrations/shared-bird.png"
+printf 'official identical art\n' \
+  >"$repo_dir/avian/assets/illustrations/identical-bird.png"
+printf 'local Swiss-only art\n' \
+  >"$repo_dir/avian/assets/illustrations/swiss-only.png"
+printf 'local German shared cutout\n' \
+  >"$repo_dir/avian/assets/cutouts/shared-photo.png"
+printf 'local German-only cutout\n' \
+  >"$repo_dir/avian/assets/cutouts/german-only.png"
 printf 'keep inside avian\n' >"$repo_dir/avian/custom-local.txt"
 printf 'keep inside frontend\n' >"$repo_dir/avian/frontend/custom-local.json"
 printf 'keep me\n' >"$repo_dir/custom/notes.txt"
@@ -363,10 +505,25 @@ expect_success 'legacy migration'
   || fail 'legacy migration did not set the release upstream'
 grep -qx 'official collision' "$repo_dir/avian/legacy.txt" \
   || fail 'release file did not replace legacy collision'
-grep -qx 'legacy masks' "$repo_dir/avian/frontend/masks.json" \
+grep -q '"swiss-only"' "$repo_dir/avian/frontend/masks.json" \
   || fail 'legacy masks.json was not preserved'
-grep -qx 'legacy dims' "$repo_dir/avian/frontend/dims.json" \
+grep -q '"swiss-only"' "$repo_dir/avian/frontend/dims.json" \
   || fail 'legacy dims.json was not preserved'
+grep -qx 'local Swiss shared art' \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  || fail 'modified regional illustration collision was not preserved'
+grep -qx 'official identical art' \
+  "$repo_dir/avian/assets/illustrations/identical-bird.png" \
+  || fail 'byte-identical regional illustration collision was not preserved'
+grep -qx 'local Swiss-only art' \
+  "$repo_dir/avian/assets/illustrations/swiss-only.png" \
+  || fail 'unique regional illustration was not preserved'
+grep -qx 'local German shared cutout' \
+  "$repo_dir/avian/assets/cutouts/shared-photo.png" \
+  || fail 'modified regional cutout collision was not preserved'
+grep -qx 'local German-only cutout' \
+  "$repo_dir/avian/assets/cutouts/german-only.png" \
+  || fail 'unique regional cutout was not preserved'
 grep -qx 'keep inside avian' "$repo_dir/avian/custom-local.txt" \
   || fail 'noncolliding file inside a release directory was not preserved'
 grep -qx 'keep inside frontend' "$repo_dir/avian/frontend/custom-local.json" \
@@ -382,6 +539,38 @@ mkdir -p "$test_root/legacy-restore"
 tar -C "$test_root/legacy-restore" -xf "$legacy_backup/legacy-collisions.tar"
 grep -qx 'legacy local copy' "$test_root/legacy-restore/avian/legacy.txt" \
   || fail 'legacy backup did not preserve the collided file'
+tar -C "$test_root/legacy-restore" -xf "$legacy_backup/custom-bird-art.tar"
+grep -qx 'local Swiss shared art' \
+  "$test_root/legacy-restore/avian/assets/illustrations/shared-bird.png" \
+  || fail 'custom-art backup did not preserve the modified collision'
+grep -qx 'local German shared cutout' \
+  "$test_root/legacy-restore/avian/assets/cutouts/shared-photo.png" \
+  || fail 'custom-art backup did not preserve the cutout collision'
+
+# The next release updates an already-overridden tracked illustration and starts
+# tracking a formerly unique Swiss file. Both local assets must remain active.
+git -C "$remote" update-ref refs/heads/avian-visitors "$release_three"
+expect_success 'subsequent update with regional overrides'
+[ "$(as_station "$station_user" "$station_home" git -C "$repo_dir" rev-parse HEAD)" \
+  = "$release_three" ] \
+  || fail 'subsequent regional update did not reach the new release'
+grep -qx 'local Swiss shared art' \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  || fail 'subsequent update replaced a tracked regional override'
+grep -qx 'local Swiss-only art' \
+  "$repo_dir/avian/assets/illustrations/swiss-only.png" \
+  || fail 'subsequent update replaced a newly colliding regional illustration'
+grep -qx 'local German shared cutout' \
+  "$repo_dir/avian/assets/cutouts/shared-photo.png" \
+  || fail 'subsequent update replaced a tracked regional cutout override'
+grep -qx 'local German-only cutout' \
+  "$repo_dir/avian/assets/cutouts/german-only.png" \
+  || fail 'subsequent update changed a unique regional cutout'
+grep -q '"swiss-only"' "$repo_dir/avian/frontend/masks.json" \
+  || fail 'subsequent update replaced regional masks.json'
+grep -q '"swiss-only"' "$repo_dir/avian/frontend/dims.json" \
+  || fail 'subsequent update replaced regional dims.json'
+git -C "$remote" update-ref refs/heads/avian-visitors "$release_two"
 
 # Model a legacy Pi that first cloned main at depth one, then shallow-fetched
 # an early AvianVisitors release. Both boundaries remain in .git/shallow, so a
@@ -455,10 +644,16 @@ fi
   || fail 'failed migration did not restore the original fetch mapping'
 
 setup_case rollback main
-mkdir -p "$repo_dir/avian/frontend" "$repo_dir/custom"
+mkdir -p "$repo_dir/avian/frontend" "$repo_dir/avian/assets/illustrations" \
+  "$repo_dir/avian/assets/cutouts" "$repo_dir/custom"
 printf 'restore this copy\n' >"$repo_dir/avian/legacy.txt"
-printf 'restore masks\n' >"$repo_dir/avian/frontend/masks.json"
-printf 'restore dims\n' >"$repo_dir/avian/frontend/dims.json"
+printf '{"shared-bird":{"w":2,"h":2,"bits":"AA=="}}\n' \
+  >"$repo_dir/avian/frontend/masks.json"
+printf '{"shared-bird":[2,2]}\n' >"$repo_dir/avian/frontend/dims.json"
+printf 'restore custom Swiss art\n' \
+  >"$repo_dir/avian/assets/illustrations/shared-bird.png"
+printf 'restore custom German cutout\n' \
+  >"$repo_dir/avian/assets/cutouts/shared-photo.png"
 printf 'keep this too\n' >"$repo_dir/custom/notes.txt"
 chown -R "$station_user:$station_user" "$repo_dir/avian" "$repo_dir/custom"
 cat >"$repo_dir/.git/hooks/post-merge" <<EOF
@@ -480,10 +675,16 @@ if as_station "$station_user" "$station_home" git -C "$repo_dir" \
 fi
 grep -qx 'restore this copy' "$repo_dir/avian/legacy.txt" \
   || fail 'failed migration did not restore collision'
-grep -qx 'restore masks' "$repo_dir/avian/frontend/masks.json" \
+grep -q '"shared-bird"' "$repo_dir/avian/frontend/masks.json" \
   || fail 'failed migration did not restore masks.json'
-grep -qx 'restore dims' "$repo_dir/avian/frontend/dims.json" \
+grep -q '"shared-bird"' "$repo_dir/avian/frontend/dims.json" \
   || fail 'failed migration did not restore dims.json'
+grep -qx 'restore custom Swiss art' \
+  "$repo_dir/avian/assets/illustrations/shared-bird.png" \
+  || fail 'failed migration did not restore custom illustration collision'
+grep -qx 'restore custom German cutout' \
+  "$repo_dir/avian/assets/cutouts/shared-photo.png" \
+  || fail 'failed migration did not restore custom cutout collision'
 grep -qx 'keep this too' "$repo_dir/custom/notes.txt" \
   || fail 'failed migration changed unrelated file'
 

--- a/tests/test_atlas_always_all.py
+++ b/tests/test_atlas_always_all.py
@@ -1,0 +1,11 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is unavailable")
+def test_atlas_always_all_preference_is_independent():
+    smoke = Path(__file__).with_name("smoke_atlas_always_all.mjs")
+    subprocess.run(["node", str(smoke)], check=True)

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "python-app.yml"
+
+
+def test_python_application_runs_for_release_branch():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'branches: [ "main", "test_me", "avian-visitors" ]' in workflow
+    assert 'branches: [ "main", "avian-visitors" ]' in workflow

--- a/tests/test_postcard_title_descenders.py
+++ b/tests/test_postcard_title_descenders.py
@@ -1,0 +1,70 @@
+import math
+import re
+from pathlib import Path
+
+from PIL import ImageFont
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CSS = (ROOT / "avian/frontend/styles.css").read_text()
+NAMES = (
+    "Herring Gull",       # g
+    "Steller's Jay",      # j, y
+    "Purple Finch",       # p
+    "Gambel's Quail",     # q
+    "Yellow Warbler",     # y
+)
+
+
+def title_rule():
+    match = re.search(r"\.postcard-heading h2\s*\{(?P<body>.*?)\n\}", CSS, re.S)
+    assert match, "postcard title rule is missing"
+    return match.group("body")
+
+
+def serif_fonts():
+    paths = [
+        Path("/System/Library/Fonts/NewYork.ttf"),
+        Path("/System/Library/Fonts/Supplemental/Georgia.ttf"),
+        Path("/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"),
+    ]
+    available = [path for path in paths if path.is_file()]
+    assert available, "no representative UI serif is installed"
+    return available
+
+
+def test_postcard_title_clip_clears_descenders_at_every_breakpoint_and_theme():
+    body = title_rule()
+    padding = float(re.search(r"padding-block-end:\s*([.\d]+)em", body).group(1))
+    line_height = float(re.search(r"clamp\([^)]*\)/([.\d]+)", body).group(1))
+
+    assert "overflow: hidden" in body
+    assert "-webkit-line-clamp: 2" in body
+    assert padding >= 0.16
+    assert set("gjpqy") <= set("".join(NAMES).lower())
+
+    # These are the actual desktop, tablet, phone, compact-landscape and
+    # narrow-phone title ceilings in styles.css. The base padding is logical,
+    # so the same allowance must clear every one in both color themes.
+    responsive_sizes = (34, 36, 32, 25, 20)
+    assert "font-size: clamp(27px, 5vw, 36px)" in CSS
+    assert "font-size: clamp(24px, 7vw, 32px)" in CSS
+    assert "font-size: clamp(20px, 3.6vw, 25px)" in CSS
+    assert "font-size: 20px" in CSS
+    assert not re.search(
+        r':root\[data-theme="dark"\]\s+\.postcard-heading h2\s*\{', CSS
+    )
+
+    for theme in ("light", "dark"):
+        for size in responsive_sizes:
+            clip_bottom = size * (line_height + padding)
+            for path in serif_fonts():
+                font = ImageFont.truetype(str(path), size)
+                ascent, descent = font.getmetrics()
+                assert clip_bottom + 0.5 >= ascent + descent, (
+                    theme, size, path.name, clip_bottom, ascent + descent
+                )
+                for name in NAMES:
+                    assert font.getbbox(name)[3] <= math.ceil(clip_bottom), (
+                        theme, size, path.name, name
+                    )

--- a/tests/test_stamp_issues.py
+++ b/tests/test_stamp_issues.py
@@ -1,0 +1,11 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is unavailable")
+def test_reviewed_stamp_issue_assignments():
+    smoke = Path(__file__).with_name("smoke_stamp_issues.sh")
+    subprocess.run([str(smoke)], check=True)


### PR DESCRIPTION
## Summary

- add an opt-in "Always show full Atlas" setting without changing the collage or Stats time window
- keep every species on an approved stamp issue, including corrected family mappings and a stable universal fallback
- preserve title descenders in expanded postcards
- preserve custom illustration and cutout libraries, plus their paired masks and dimensions, across migration and later updates
- serialize illustration generation and updates through a shared root-owned lock
- run the focused Atlas, stamp, postcard, updater, generation, and release-branch regressions in CI

## Verification

- Atlas preference, cross-tab sync, stamp issue, and descender smokes pass
- updater, generation API, pre-v1 bootstrap, admin/security, and service-refresh smokes pass
- shell, JavaScript, Python, PHP, workflow, and diff checks pass
- no illustration bundle is added to the core bird library

This PR intentionally preserves the eight focused commits and their reviewable history.