### PR TITLE
Update illustration-bundles.md

### DIFF
--- a/illustration-bundles.md
+++ b/illustration-bundles.md
@@ -14,6 +14,7 @@ The main repo ships a Western-US set reviewed by hand. Other people have generat
 - **The Iberian Peninsula**: [RoqueAlonso's fork](https://github.com/RoqueAlonso/AvianVisitors/tree/iberia-illustrations), 440 species. Work in progress: covers Madrid and Castilla-La Mancha (ES-MD, ES-CM) in full, with partial coverage elsewhere in the Peninsula.
 - **Derbyshire, UK**: [jonnywright's repo](https://github.com/jonnywright/AvianAssets), not a full fork but just the illustrations, `dims.json` and `masks.json` for 302 species from Derbyshire, UK (GB-ENG-DBY).
 - **England, UK**: [lloydalexporter's repo](https://github.com/lloydalexporter/AvianAssets_GB-ENG), just the illustration assets for 724 species.
+- - **Netherlands (NL-GR)**: [peterdeboer-nl's fork](https://github.com/peterdeboer-nl/AvianVisitors/tree/avian-visitors), 572 species
 
 ## South America
 


### PR DESCRIPTION
Adds a Netherlands (NL-GR) bundle to the list, generated with the eBird region filter for Groningen. Illustrations live on the avian-visitors branch of my fork;