### PR TITLE
feat(frame): follow an exact BirdWeather station

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Everything outside `avian/` and `frame/` is upstream BirdNET-Pi.
 
 ## Wall frame
 
-An optional e-ink frame mirrors the last 24h of birds onto a panel by your window. Build it from [`frame/`](frame/README.md). It can run off your own BirdNET mic, or standalone from BirdWeather data for any ZIP code with no mic at all.
+An optional e-ink frame puts the bird collage on a panel by your window. Build it from [`frame/`](frame/README.md). It can run off your own BirdNET mic, from BirdWeather around a ZIP code, or from one public BirdWeather station with `frame/install.sh --station-id <ID>`.
 
 ---
 

--- a/frame/README.md
+++ b/frame/README.md
@@ -61,13 +61,16 @@ Pick how the frame gets its birds:
 # No microphone: draw the collage from BirdWeather for any ZIP code.
 ./install.sh --bird-weather --zip 94107
 
+# No microphone: follow one public BirdWeather station exactly.
+./install.sh --station-id 12345
+
 # Bird mic hosted at a public URL: point the frame straight at it.
 ./install.sh --image-url https://bird.onethreenine.net/frame.png?k=YOUR_FRAME_KEY
 ```
 
-Each one enables SPI + I2C, installs the deps and a systemd timer, writes `~/.birdframe/config.toml`, and reboots once to bring SPI up. Full options live in [`config.example.toml`](config.example.toml).
+Each one enables SPI + I2C, installs the deps and a systemd timer, writes `~/.birdframe/config.toml`, and reboots once to bring SPI up. Full options live in [`config.example.toml`](config.example.toml). The station ID is the public number at the end of a BirdWeather station-page URL, not its upload token. ZIP mode summarizes nearby stations and can use fallbacks; station mode shows only that station and fails rather than substituting another source.
 
-The default layout matches the A5 opening in the frame listed above. If you use a different mat or a bare panel, set `opening` in `~/.birdframe/config.toml`; `0.7071` preserves the current A5 dimensions, while values up to about `0.98` use more of the panel.
+The default layout matches the A5 opening in the frame listed above. If you use a different mat or a bare panel, set `opening` in `~/.birdframe/config.toml`; `0.7071` preserves the current A5 dimensions, while values up to about `0.98` use more of the panel. This one setting scales a fixed 1:sqrt(2) opening, not width and height independently. For a B5 opening, `0.84` is a useful starting point, but check it against your physical mat.
 
 Bird names are off on the frame by default. Turn them on or off at any time; the command saves the preference and requests an immediate refresh:
 
@@ -76,14 +79,18 @@ birdframe-names on
 birdframe-names off
 ```
 
+Set `shoot_title = ""` in `~/.birdframe/config.toml` if you want to hide only the frame title.
+
 For an `--image-url` frame, the command adds `labels=1` or `labels=0` to the source URL. The source must honor that setting; otherwise its image will not change.
 
-BirdWeather mode renders on the Pi from this repo's illustrations on GitHub, so there is no image set to copy over. ZIP codes with no station nearby fall back to the closest ones. If you are far from any BirdWeather station, add `--ebird-key <key>` (a free key from [ebird.org/api/keygen](https://ebird.org/api/keygen)) and the frame fills from eBird sightings instead.
+BirdWeather mode renders on the Pi from this repo's illustrations on GitHub, so there is no image set to copy over. In ZIP mode, postal codes with no station nearby fall back to the closest ones. If you are far from any BirdWeather station, add `--ebird-key <key>` (a free key from [ebird.org/api/keygen](https://ebird.org/api/keygen)) and the frame fills from eBird sightings instead. Exact station mode has no geographic or eBird fallback.
 
-The bundled illustrations center on the western U.S. If birds near your ZIP aren't in the set you cloned, the installer flags them and the frame skips them until they exist. To generate them, run [`generate_illustrations.py`](generate_illustrations.py) on a laptop or workstation (it uses the same rembg cutout as the rest of the pipeline, which the Pi can't fit in memory), passing your ZIP and a paid Google Gemini key, then commit the new cutouts or copy them to the Pi:
+The bundled illustrations center on the western U.S. If birds for your ZIP or station aren't in the set you cloned, the installer flags them and the frame skips them until they exist. To generate them, run [`generate_illustrations.py`](generate_illustrations.py) on a laptop or workstation (it uses the same rembg cutout as the rest of the pipeline, which the Pi can't fit in memory), passing your source and a paid Google Gemini key, then commit the new cutouts or copy them to the Pi:
 
 ```bash
 python3 generate_illustrations.py --zip 10001 --gemini-key YOUR_GEMINI_KEY
+# or for one station
+python3 generate_illustrations.py --station-id 12345 --gemini-key YOUR_GEMINI_KEY
 ```
 
-It generates only the species you're missing; `--country` and `--sample` carry through for non-US postcodes or a wider region.
+It generates only the species you're missing. `--country` supports non-US postcodes, and `--sample` controls how many top species are checked.

--- a/frame/birdweather.py
+++ b/frame/birdweather.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Top recently-heard birds near a ZIP, from BirdWeather, for the frame's
---bird-weather mode.
+"""Top recently-heard birds near a ZIP or one BirdWeather station for the
+frame's --bird-weather mode.
 
 Returns the shape the collage already expects, [{"sci","com","n"}], so the
 existing renderer draws it unchanged. Standalone (Python stdlib only). Filtered
@@ -26,17 +26,59 @@ _drawable = None
 _GEO_CACHE = os.path.expanduser("~/.birdframe/geocode.json")
 
 
-def _graphql(query, timeout):
+class BirdWeatherError(RuntimeError):
+    """A public BirdWeather lookup failed or returned an unsafe shape."""
+
+
+def _graphql(query, timeout, variables=None, strict=False):
+    body = {"query": query}
+    if variables is not None:
+        body["variables"] = variables
     req = urllib.request.Request(
         BIRDWEATHER,
-        data=json.dumps({"query": query}).encode(),
+        data=json.dumps(body).encode(),
         headers={"Content-Type": "application/json", "User-Agent": "AvianVisitors-frame/1.0"},
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
-            return json.loads(r.read(2_000_000))
-    except Exception:
+            raw = r.read(2_000_001)
+        if len(raw) > 2_000_000:
+            raise BirdWeatherError("BirdWeather response is too large")
+        payload = json.loads(raw)
+        if not isinstance(payload, dict) or payload.get("errors"):
+            raise BirdWeatherError("BirdWeather returned an invalid response")
+        if strict and not isinstance(payload.get("data"), dict):
+            raise BirdWeatherError("BirdWeather response has no data")
+        return payload
+    except Exception as exc:
+        if strict:
+            if isinstance(exc, BirdWeatherError):
+                raise
+            raise BirdWeatherError("BirdWeather lookup failed") from exc
         return {}  # a transient upstream failure degrades to the next radius or fallback
+
+
+def station_id(value):
+    """Return a canonical public numeric station ID, or raise ValueError.
+
+    BirdWeather station IDs are public identifiers, not station upload tokens.
+    Keep this aligned with the website's 32-bit station-ID boundary.
+    """
+    if isinstance(value, bool):
+        raise ValueError("station ID must be a number from 1 through 2147483647")
+    text = str(value)
+    if not re.fullmatch(r"[1-9][0-9]{0,9}", text):
+        raise ValueError("station ID must be a number from 1 through 2147483647")
+    number = int(text)
+    if number > 2147483647:
+        raise ValueError("station ID must be a number from 1 through 2147483647")
+    return str(number)
+
+
+def _bounded_int(value, name, low, high):
+    if isinstance(value, bool) or not isinstance(value, int) or not low <= value <= high:
+        raise ValueError(f"{name} must be from {low} through {high}")
+    return value
 
 
 def geocode(zip_code, country="us", timeout=20):
@@ -96,6 +138,64 @@ def top_species(lat, lon, miles, days=7, limit=60, timeout=20):
         sci = sp.get("scientificName")
         if sci:
             out.append({"sci": sci, "com": sp.get("commonName") or sci, "n": row.get("count") or 1})
+    return out
+
+
+def top_species_for_station(value, days=7, limit=60, timeout=20):
+    """BirdWeather's species for exactly one public station.
+
+    This path is intentionally strict and has no geographic or eBird fallback.
+    A station-tethered frame must never substitute another station's birds.
+    """
+    sid = station_id(value)
+    days = _bounded_int(days, "days", 1, 365)
+    limit = _bounded_int(limit, "limit", 1, 200)
+    query = """
+query FrameStation($stationId: ID!, $stationIds: [ID!]!, $period: InputDuration!, $limit: Int!) {
+  station(id: $stationId) { id }
+  topSpecies(stationIds: $stationIds, period: $period, limit: $limit) {
+    count
+    species { commonName scientificName }
+  }
+}
+""".strip()
+    payload = _graphql(query, timeout, variables={
+        "stationId": sid,
+        "stationIds": [sid],
+        "period": {"count": days, "unit": "day"},
+        "limit": limit,
+    }, strict=True)
+    data = payload["data"]
+    station = data.get("station")
+    if not isinstance(station, dict):
+        raise BirdWeatherError(f"BirdWeather station {sid} was not found")
+    try:
+        returned_id = station_id(station.get("id"))
+    except ValueError as exc:
+        raise BirdWeatherError("BirdWeather returned an invalid station") from exc
+    if returned_id != sid:
+        raise BirdWeatherError("BirdWeather returned a different station")
+    rows = data.get("topSpecies")
+    if not isinstance(rows, list):
+        raise BirdWeatherError("BirdWeather returned an invalid species list")
+
+    out = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise BirdWeatherError("BirdWeather returned an invalid species row")
+        sp = row.get("species")
+        count = row.get("count")
+        if (not isinstance(sp, dict) or isinstance(count, bool)
+                or not isinstance(count, int) or count < 1):
+            raise BirdWeatherError("BirdWeather returned an invalid species row")
+        sci = sp.get("scientificName")
+        com = sp.get("commonName")
+        if not isinstance(sci, str) or not sci.strip():
+            raise BirdWeatherError("BirdWeather returned an invalid species row")
+        if not isinstance(com, str) or not com.strip():
+            com = sci
+        out.append({"sci": sci, "com": com, "n": count})
+    out.sort(key=lambda s: -s["n"])
     return out
 
 
@@ -234,6 +334,15 @@ def species_for_zip(zip_code, country="us", target=10, days=7, radii=(15, 30, 50
     return found[:target]
 
 
+def species_for_station(value, target=10, days=7, apt_js=APT_JS, timeout=20):
+    """Top drawable birds heard by exactly one public BirdWeather station."""
+    target = _bounded_int(target, "target", 1, 60)
+    drawable = drawable_slugs(apt_js)
+    found = [s for s in top_species_for_station(value, days, max(60, target), timeout)
+             if slugify(s["sci"]) in drawable]
+    return found[:target]
+
+
 def coverage_for_zip(zip_code, country="us", sample=15, days=7, radii=(15, 30, 50),
                      apt_js=APT_JS, timeout=20):
     """Split the ZIP's most-detected birds by whether the repo can draw them.
@@ -269,23 +378,51 @@ def coverage_for_zip(zip_code, country="us", sample=15, days=7, radii=(15, 30, 5
     return have, missing
 
 
+def coverage_for_station(value, sample=15, days=7, apt_js=APT_JS, timeout=20):
+    """Split one station's top species by whether the frame can draw them."""
+    sample = _bounded_int(sample, "sample", 1, 60)
+    top = top_species_for_station(value, days, sample, timeout)
+    drawable = drawable_slugs(apt_js)
+    have = [s for s in top if slugify(s["sci"]) in drawable]
+    missing = [s for s in top if slugify(s["sci"]) not in drawable]
+    return have, missing
+
+
 if __name__ == "__main__":
     import argparse
     import sys
-    ap = argparse.ArgumentParser(description="BirdWeather top species for a ZIP.")
-    ap.add_argument("zip")
+    ap = argparse.ArgumentParser(description="BirdWeather top species for a ZIP or station.")
+    ap.add_argument("zip", nargs="?")
+    ap.add_argument("--station-id", help="Public numeric ID at the end of a BirdWeather station URL.")
     ap.add_argument("--country", default="us")
     ap.add_argument("--target", type=int, default=10)
     ap.add_argument("--days", type=int, default=7)
     ap.add_argument("--missing", action="store_true",
-                    help="Print the ZIP's top LOCAL birds the repo can't draw yet "
+                    help="Print the source's top birds the repo can't draw yet "
                          "as Sci|Com lines (feed to pregen.py --stdin); summary to stderr.")
     ap.add_argument("--sample", type=int, default=15,
-                    help="How many of the ZIP's top birds to weigh for --missing (default 15).")
+                    help="How many of the source's top birds to weigh for --missing (default 15).")
+    ap.add_argument("--check-station", action="store_true",
+                    help="Validate one --station-id without requiring any detections.")
     a = ap.parse_args()
+    if bool(a.zip) == bool(a.station_id):
+        ap.error("provide exactly one ZIP or --station-id")
+    if a.check_station:
+        if not a.station_id or a.missing:
+            ap.error("--check-station requires --station-id and cannot be combined with --missing")
+        try:
+            top_species_for_station(a.station_id, a.days, 1)
+        except (ValueError, BirdWeatherError) as e:
+            print(f"station lookup failed: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(f"BirdWeather station {station_id(a.station_id)} is available")
+        sys.exit(0)
     if a.missing:
         try:
-            have, missing = coverage_for_zip(a.zip, a.country, a.sample, a.days)
+            if a.station_id:
+                have, missing = coverage_for_station(a.station_id, a.sample, a.days)
+            else:
+                have, missing = coverage_for_zip(a.zip, a.country, a.sample, a.days)
         except Exception as e:
             # Never break the installer: no data just means no generation offer.
             print(f"coverage lookup failed: {e}", file=sys.stderr)
@@ -293,8 +430,13 @@ if __name__ == "__main__":
         for s in missing:
             print(f'{s["sci"]}|{s["com"]}')
         total = len(have) + len(missing)
-        print(f"{len(have)} of the top {total} birds near {a.zip} are bundled; "
+        where = f"station {station_id(a.station_id)}" if a.station_id else f"{a.zip}"
+        print(f"{len(have)} of the top {total} birds for {where} are bundled; "
               f"{len(missing)} are not.", file=sys.stderr)
     else:
-        for s in species_for_zip(a.zip, a.country, a.target, a.days):
+        if a.station_id:
+            species = species_for_station(a.station_id, a.target, a.days)
+        else:
+            species = species_for_zip(a.zip, a.country, a.target, a.days)
+        for s in species:
             print(f'{s["n"]:>8}  {s["com"]}  ({s["sci"]})')

--- a/frame/config.example.toml
+++ b/frame/config.example.toml
@@ -14,10 +14,11 @@ shoot = true
 # Or read a PNG a sibling process drops next to us:
 # image = "~/.birdframe/frame.png"
 
-# Or render from BirdWeather for any ZIP, no mic (what install.sh --bird-weather
-# writes). The panel still refreshes only when the local top birds change:
+# Or render from BirdWeather, no mic. Choose one locator. The panel still
+# refreshes only when that source's top birds change:
 # species_source = "birdweather"
 # zip = "94107"
+# bw_station_id = "12345"  # public number at the end of the station-page URL; use instead of zip
 # bw_days = 7          # BirdWeather lookback window, in days
 # bw_country = "us"    # geocoder country for the ZIP
 # shoot = true         # this Pi renders the collage
@@ -27,6 +28,7 @@ hours = 24             # window shown on the frame
 # --- Titles and look (used when this Pi renders, i.e. shoot = true) ----------
 shoot_title = "Avian Visitors"
 shoot_subtitle = "Heard Today"
+# Set shoot_title = "" to hide the frame title without hiding bird names.
 bird_names = false       # run `birdframe-names on` to show them
 # shoot_headline_px = 42
 # shoot_eyebrow_px = 18

--- a/frame/config_contract.py
+++ b/frame/config_contract.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Verify that an existing frame config still selects the requested source.
+
+The installer leaves existing configs untouched. Before it changes the host, it
+uses this semantic TOML check so a rerun cannot claim a different source was
+installed while preserving an old, malformed, or ambiguous config.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
+
+
+def _inactive(value):
+    return value in (None, "", 0, False)
+
+
+def _station_id(value):
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        text = str(value)
+    elif isinstance(value, str):
+        text = value
+    else:
+        return None
+    if not text.isascii() or not text.isdecimal() or text.startswith("0"):
+        return None
+    number = int(text)
+    return text if 1 <= number <= 2147483647 else None
+
+
+def _http_url(value):
+    if not isinstance(value, str) or any(ch.isspace() or ord(ch) < 32 for ch in value):
+        return False
+    try:
+        parts = urlsplit(value)
+        host = parts.hostname
+        parts.port
+    except ValueError:
+        return False
+    return parts.scheme in ("http", "https") and bool(host)
+
+
+def verify(path, mode, station=None, zip_code=None, image_url=None):
+    try:
+        raw = path.read_bytes()
+        data = tomllib.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+
+    species_source = data.get("species_source", "")
+    active_station = not _inactive(data.get("bw_station_id"))
+    active_zip = isinstance(data.get("zip"), str) and bool(data["zip"].strip())
+    image_url_value = data.get("image_url")
+    image_value = data.get("image")
+    active_image_url = isinstance(image_url_value, str) and bool(image_url_value)
+    active_image = isinstance(image_value, str) and bool(image_value)
+    valid_image_values = (
+        (not image_url_value or isinstance(image_url_value, str))
+        and (not image_value or isinstance(image_value, str))
+    )
+    selected_image = image_url_value or image_value
+
+    if mode == "local":
+        local_capture = (
+            data.get("shoot") is True
+            and _http_url(data.get("base_url"))
+            and not active_image_url
+            and not active_image
+        )
+        preserved_image = (
+            data.get("shoot") is False
+            and valid_image_values
+            and isinstance(selected_image, str)
+            and bool(selected_image)
+        )
+        return (
+            species_source == ""
+            and not active_station
+            and not active_zip
+            and (local_capture or preserved_image)
+        )
+    if mode == "image":
+        return (
+            species_source == ""
+            and not active_station
+            and not active_zip
+            and valid_image_values
+            and data.get("shoot") is False
+            and image_url_value == image_url
+        )
+    if mode == "birdweather" and station is not None:
+        return (
+            species_source == "birdweather"
+            and _station_id(data.get("bw_station_id")) == station
+            and not active_zip
+            and not active_image_url
+            and not active_image
+        )
+    if mode == "birdweather" and zip_code is not None:
+        country = data.get("bw_country", "us")
+        return (
+            species_source == "birdweather"
+            and not active_station
+            and isinstance(data.get("zip"), str)
+            and data["zip"].strip() == zip_code
+            and isinstance(country, str)
+            and bool(country.strip())
+            and not active_image_url
+            and not active_image
+        )
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", type=Path)
+    parser.add_argument("--mode", required=True, choices=("local", "image", "birdweather"))
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--station-id")
+    source.add_argument("--zip")
+    source.add_argument("--image-url")
+    args = parser.parse_args()
+    ok = verify(args.config, args.mode, args.station_id, args.zip, args.image_url)
+    if not ok:
+        print("existing frame config does not select the requested source", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frame/display.py
+++ b/frame/display.py
@@ -41,8 +41,9 @@ SPECTRA6 = [(236, 234, 223), (26, 26, 28), (165, 60, 56),
 
 DEFAULTS = {
     "base_url": "http://birdnet.local",
-    "species_source": "",   # "" = the recent API at base_url; "birdweather" = BirdWeather near a ZIP
-    "zip": "",              # BirdWeather ZIP / postal code (with species_source = "birdweather")
+    "species_source": "",   # "" = the recent API; "birdweather" = one station or a ZIP
+    "zip": "",              # BirdWeather ZIP / postal code (use one locator only)
+    "bw_station_id": "",    # public BirdWeather station ID (use instead of zip)
     "bw_days": 7,           # BirdWeather lookback window, in days
     "bw_country": "us",     # geocoder country for the ZIP
     "hours": 24,
@@ -95,18 +96,45 @@ def fetch_recent(base, hours, timeout, auth=None):
         return json.loads(r.read(2_000_000)).get("species", [])
 
 
-def signature(species):
+def signature(species, scope=""):
     items = sorted((slugify(s["sci"]), _bucket(int(s.get("n") or 1))) for s in species)
-    return hashlib.sha256(json.dumps(items).encode()).hexdigest()[:16]
+    material = [scope, items] if scope else items
+    return hashlib.sha256(json.dumps(material).encode()).hexdigest()[:16]
+
+
+def birdweather_locator(cfg):
+    """Return (kind, value) for the one configured BirdWeather source."""
+    station = cfg.get("bw_station_id")
+    has_station = station not in (None, "", 0)
+    zip_code = cfg.get("zip")
+    has_zip = isinstance(zip_code, str) and bool(zip_code.strip())
+    if has_station and has_zip:
+        raise ValueError("BirdWeather config must use either bw_station_id or zip, not both")
+    if has_station:
+        import birdweather
+        return "station", birdweather.station_id(station)
+    if has_zip:
+        return "zip", zip_code.strip()
+    raise ValueError("BirdWeather config needs bw_station_id or zip")
+
+
+def birdweather_signature_scope(cfg):
+    kind, value = birdweather_locator(cfg)
+    if kind == "station":
+        return f"birdweather:station:{value}:days:{cfg['bw_days']}"
+    return f"birdweather:zip:{cfg['bw_country']}:{value}:days:{cfg['bw_days']}"
 
 
 def fetch_species(cfg, auth=None):
     """The species list the signature is built from: the BirdNET-Pi recent API
-    by default, or BirdWeather's recent detections near a ZIP when
+    by default, or BirdWeather detections from one station or near a ZIP when
     species_source = "birdweather"."""
     if cfg.get("species_source") == "birdweather":
         import birdweather
-        return birdweather.species_for_zip(cfg["zip"], country=cfg["bw_country"], days=cfg["bw_days"])
+        kind, value = birdweather_locator(cfg)
+        if kind == "station":
+            return birdweather.species_for_station(value, days=cfg["bw_days"])
+        return birdweather.species_for_zip(value, country=cfg["bw_country"], days=cfg["bw_days"])
     return fetch_recent(cfg["base_url"], cfg["hours"], cfg["timeout"], auth)
 
 
@@ -364,7 +392,8 @@ def run(cfg, preview=None, force=False, use_signature=True, mat_box=False):
     if use_signature:
         try:
             species = fetch_species(cfg, _auth(cfg))
-            sig = signature(species)
+            scope = birdweather_signature_scope(cfg) if cfg.get("species_source") == "birdweather" else ""
+            sig = signature(species, scope)
         except Exception as e:
             print(f"signature fetch failed: {e}", file=sys.stderr)  # treat as no change
     heal_due = now - state.get("last_refresh", 0) >= cfg["heal_hours"] * 3600

--- a/frame/generate_illustrations.py
+++ b/frame/generate_illustrations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Generate the kachō-e illustrations a ZIP needs but the repo doesn't bundle.
+"""Generate the kachō-e illustrations a ZIP or station needs but the repo doesn't bundle.
 
-Compares a ZIP's most-detected birds (BirdWeather) against the bundled
+Compares one ZIP or BirdWeather station's most-detected birds against the bundled
 illustration set and, for the gap, runs the repo's illustration pipeline:
 
     pregen.py (Gemini, cream ground)
@@ -21,8 +21,9 @@ history) or let it prompt:
     GEMINI_API_KEY=KEY python3 frame/generate_illustrations.py --zip 10001
     python3 frame/generate_illustrations.py --zip 10001            # prompts for the key
     python3 frame/generate_illustrations.py --zip 10001 --gemini-key KEY
+    python3 frame/generate_illustrations.py --station-id 12345
 
---country and --sample carry through for non-US postcodes or a wider region.
+--country supports non-US postcodes; --sample controls how many top species are checked.
 """
 from __future__ import annotations
 
@@ -81,31 +82,43 @@ def _generate(missing, key):
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--zip", required=True)
+    source = ap.add_mutually_exclusive_group(required=True)
+    source.add_argument("--zip")
+    source.add_argument("--station-id", help="Public numeric BirdWeather station ID.")
     ap.add_argument("--country", default="us")
     ap.add_argument("--gemini-key", default=os.environ.get("GEMINI_API_KEY", ""),
                     help="Paid Google Gemini API key (or GEMINI_API_KEY env).")
     ap.add_argument("--sample", type=int, default=15,
-                    help="How many of the ZIP's top birds to weigh (default 15).")
+                    help="How many of the source's top birds to weigh (default 15).")
     a = ap.parse_args()
 
+    if a.station_id:
+        try:
+            source_name = f"station {birdweather.station_id(a.station_id)}"
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 2
+    else:
+        source_name = a.zip
     try:
-        have, missing = birdweather.coverage_for_zip(a.zip, a.country, a.sample)
+        if a.station_id:
+            have, missing = birdweather.coverage_for_station(a.station_id, a.sample)
+        else:
+            have, missing = birdweather.coverage_for_zip(a.zip, a.country, a.sample)
     except Exception as e:
-        print(f"coverage lookup for {a.zip} failed ({e})", file=sys.stderr)
+        print(f"coverage lookup for {source_name} failed ({e})", file=sys.stderr)
         return 1
     total = len(have) + len(missing)
     if not missing:
         if total == 0:
-            print(f"Couldn't find local birds for {a.zip} (BirdWeather may have no "
-                  f"station nearby).")
+            print(f"Couldn't find recent birds for {source_name}.")
         else:
-            print(f"All {total} of the top birds near {a.zip} are already bundled - "
+            print(f"All {total} of the top birds for {source_name} are already bundled - "
                   f"nothing to generate.")
         return 0
 
     names = ", ".join(s["com"] for s in missing[:6]) + (" ..." if len(missing) > 6 else "")
-    print(f"{len(missing)} of the top {total} birds near {a.zip} aren't bundled:\n  {names}")
+    print(f"{len(missing)} of the top {total} birds for {source_name} aren't bundled:\n  {names}")
 
     key = a.gemini_key
     if not key:

--- a/frame/install.sh
+++ b/frame/install.sh
@@ -2,27 +2,33 @@
 # Install the AvianVisitors e-ink frame (display side) on a Raspberry Pi.
 # Enables SPI + I2C, installs deps, makes a venv, installs the systemd timer.
 #
-# Three ways to feed the frame, pick one:
+# Four ways to feed the frame, pick one:
 #   ./install.sh                            mirror the BirdNET-Pi on your network
 #                                           (birdnet.local), rendered on this Pi
 #   ./install.sh --image-url <URL>          fetch a ready-made frame PNG instead
 #                                           (e.g. a public Cloudflare Worker)
 #   ./install.sh --bird-weather --zip <ZIP> standalone from BirdWeather, no mic
 #                                           (add --ebird-key <KEY> for remote ZIPs)
+#   ./install.sh --station-id <ID>           follow one public BirdWeather station
 set -euo pipefail
 cd "$(dirname "$0")"
 FRAME="$(pwd)"
 
 MODE=local            # local | image | birdweather
+BIRD_WEATHER=0
 ZIP=""
+STATION_ID=""
 IMAGE_URL=""
 EBIRD_KEY=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --bird-weather) MODE=birdweather; shift ;;
+    --bird-weather) BIRD_WEATHER=1; MODE=birdweather; shift ;;
     --zip) [ $# -ge 2 ] || { echo "--zip needs a value, e.g. --zip 94107" >&2; exit 1; }
            ZIP="$2"; shift 2 ;;
     --zip=*) ZIP="${1#*=}"; shift ;;
+    --station-id) [ $# -ge 2 ] || { echo "--station-id needs a value, e.g. --station-id 12345" >&2; exit 1; }
+                  MODE=birdweather; STATION_ID="$2"; shift 2 ;;
+    --station-id=*) MODE=birdweather; STATION_ID="${1#*=}"; shift ;;
     --image-url) [ $# -ge 2 ] || { echo "--image-url needs a URL, e.g. --image-url https://bird.example/frame.png" >&2; exit 1; }
                  MODE=image; IMAGE_URL="$2"; shift 2 ;;
     --image-url=*) MODE=image; IMAGE_URL="${1#*=}"; shift ;;
@@ -33,7 +39,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -n "$ZIP" ] && [ "$MODE" != birdweather ]; then
+if [ -n "$IMAGE_URL" ] && { [ "$BIRD_WEATHER" = 1 ] || [ -n "$ZIP" ] || [ -n "$STATION_ID" ] || [ -n "$EBIRD_KEY" ]; }; then
+  echo "--image-url cannot be combined with BirdWeather options" >&2
+  exit 1
+fi
+if [ -n "$ZIP" ] && [ "$BIRD_WEATHER" != 1 ]; then
   echo "--zip only applies with --bird-weather" >&2
   exit 1
 fi
@@ -41,18 +51,33 @@ if [ -n "$EBIRD_KEY" ] && [ "$MODE" != birdweather ]; then
   echo "--ebird-key only applies with --bird-weather" >&2
   exit 1
 fi
+if [ -n "$ZIP" ] && [ -n "$STATION_ID" ]; then
+  echo "use either --zip or --station-id, not both" >&2
+  exit 1
+fi
+if [ -n "$STATION_ID" ] && [ -n "$EBIRD_KEY" ]; then
+  echo "--ebird-key only applies to BirdWeather ZIP mode" >&2
+  exit 1
+fi
 
 # Validate inputs up front: a bad value would otherwise land in a config file or
 # a systemd unit verbatim. These checks also reject a flag passed as a value
 # (e.g. "--zip --image-url"), which would fail the format below.
 if [ "$MODE" = birdweather ]; then
-  if [ -z "$ZIP" ]; then
-    echo "--bird-weather needs --zip <ZIP code>, e.g. install.sh --bird-weather --zip 94107" >&2
+  if [ -z "$ZIP" ] && [ -z "$STATION_ID" ]; then
+    echo "BirdWeather mode needs --zip <ZIP code> or --station-id <ID>" >&2
     exit 1
   fi
-  if ! printf '%s' "$ZIP" | LC_ALL=C grep -qE '^[A-Za-z0-9][A-Za-z0-9 -]{1,9}$'; then
+  if [ -n "$ZIP" ] && ! printf '%s' "$ZIP" | LC_ALL=C grep -qE '^[A-Za-z0-9][A-Za-z0-9 -]{0,8}[A-Za-z0-9]$'; then
     echo "--zip should look like a postal code, e.g. 94107 or SW1A 1AA" >&2
     exit 1
+  fi
+  if [ -n "$STATION_ID" ]; then
+    if ! printf '%s' "$STATION_ID" | LC_ALL=C grep -qE '^[1-9][0-9]{0,9}$' \
+        || [ "$STATION_ID" -gt 2147483647 ]; then
+      echo "--station-id must be a number from 1 through 2147483647" >&2
+      exit 1
+    fi
   fi
   if [ -n "$EBIRD_KEY" ] && ! printf '%s' "$EBIRD_KEY" | LC_ALL=C grep -qE '^[A-Za-z0-9]+$'; then
     echo "--ebird-key should be the alphanumeric token from ebird.org/api/keygen" >&2
@@ -70,6 +95,52 @@ if [ "$MODE" = image ]; then
   esac
   if printf '%s' "$IMAGE_URL" | LC_ALL=C grep -q '[^A-Za-z0-9._~:/?#@!$&()*+,;=%-]'; then
     echo "--image-url has characters that are not allowed in a URL" >&2
+    exit 1
+  fi
+fi
+
+CONFIG="$HOME/.birdframe/config.toml"
+CONFIG_EXISTS=0
+if [ -f "$CONFIG" ]; then
+  CONFIG_EXISTS=1
+  CONFIG_PYTHON=""
+  if python3 -c 'import tomllib' >/dev/null 2>&1 \
+      || python3 -c 'import tomli' >/dev/null 2>&1; then
+    CONFIG_PYTHON=python3
+  elif [ -x "$FRAME/.venv/bin/python" ] \
+      && { "$FRAME/.venv/bin/python" -c 'import tomllib' >/dev/null 2>&1 \
+           || "$FRAME/.venv/bin/python" -c 'import tomli' >/dev/null 2>&1; }; then
+    CONFIG_PYTHON="$FRAME/.venv/bin/python"
+  else
+    echo "Cannot safely verify the existing frame config without Python tomllib or tomli." >&2
+    echo "Review $CONFIG manually before running the installer again." >&2
+    exit 1
+  fi
+  CONFIG_ARGS=("$CONFIG" --mode "$MODE")
+  if [ -n "$STATION_ID" ]; then CONFIG_ARGS+=(--station-id "$STATION_ID"); fi
+  if [ -n "$ZIP" ]; then CONFIG_ARGS+=(--zip "$ZIP"); fi
+  if [ -n "$IMAGE_URL" ]; then CONFIG_ARGS+=(--image-url "$IMAGE_URL"); fi
+  if ! "$CONFIG_PYTHON" "$FRAME/config_contract.py" "${CONFIG_ARGS[@]}" >/dev/null 2>&1; then
+    case "$MODE" in
+      birdweather)
+        if [ -n "$STATION_ID" ]; then
+          echo "$CONFIG does not select BirdWeather station $STATION_ID." >&2
+        else
+          echo "$CONFIG does not select BirdWeather ZIP $ZIP." >&2
+        fi
+        ;;
+      image) echo "$CONFIG does not select image URL $IMAGE_URL." >&2 ;;
+      local) echo "$CONFIG does not select a supported local or preserved image source." >&2 ;;
+    esac
+    echo "Review the file, or remove it and re-run the installer to switch sources." >&2
+    exit 1
+  fi
+fi
+
+if [ -n "$STATION_ID" ] && [ "$CONFIG_EXISTS" = 0 ]; then
+  echo "Checking public BirdWeather station $STATION_ID..."
+  if ! python3 "$FRAME/birdweather.py" --station-id "$STATION_ID" --check-station >/dev/null; then
+    echo "BirdWeather station $STATION_ID could not be verified. Check the public station-page URL and try again." >&2
     exit 1
   fi
 fi
@@ -103,14 +174,7 @@ fi
 
 echo "4/5  Writing config..."
 mkdir -p "$HOME/.birdframe"
-CONFIG="$HOME/.birdframe/config.toml"
-if [ -f "$CONFIG" ]; then
-  EXISTING="$(sed -n 's/^# birdframe-mode: //p' "$CONFIG" | head -1)"
-  if [ -n "$EXISTING" ] && [ "$EXISTING" != "$MODE" ]; then
-    echo "     $CONFIG is set up for '$EXISTING' mode, not '$MODE'." >&2
-    echo "     To switch, remove it and re-run:  rm $CONFIG" >&2
-    exit 1
-  fi
+if [ "$CONFIG_EXISTS" = 1 ]; then
   echo "     $CONFIG already exists, leaving it untouched."
 elif [ "$MODE" = local ]; then
   cat > "$CONFIG" <<'CFG'
@@ -142,15 +206,19 @@ elif [ "$MODE" = image ]; then
     printf '%s\n' 'saturation = 0.6'
   } > "$CONFIG"
 else
-  # birdweather: this Pi renders from BirdWeather near $ZIP, gated on the same
-  # signature as the other modes - it only redraws when the local top birds change.
+  # BirdWeather renders on this Pi and redraws only when that source changes.
   {
     printf '%s\n' '# birdframe-mode: birdweather'
-    printf '%s\n' '# AvianVisitors frame, BirdWeather mode: renders the top birds near a ZIP.'
     printf '%s\n' 'species_source = "birdweather"'
-    printf 'zip = "%s"\n' "$ZIP"
+    if [ -n "$STATION_ID" ]; then
+      printf '%s\n' '# AvianVisitors frame, BirdWeather mode: follows one public station.'
+      printf 'bw_station_id = "%s"\n' "$STATION_ID"
+    else
+      printf '%s\n' '# AvianVisitors frame, BirdWeather mode: renders the top birds near a ZIP.'
+      printf 'zip = "%s"\n' "$ZIP"
+      printf '%s\n' 'bw_country = "us"    # geocoder country for the ZIP'
+    fi
     printf '%s\n' 'bw_days = 7          # BirdWeather lookback window, in days'
-    printf '%s\n' 'bw_country = "us"    # geocoder country for the ZIP'
     printf '%s\n' 'shoot = true         # this Pi renders the collage'
     printf '%s\n' 'shoot_title = "Avian Visitors"'
     printf '%s\n' 'shoot_subtitle = "Heard Today"'
@@ -176,6 +244,14 @@ sudo cp systemd/birdframe.timer /etc/systemd/system/birdframe.timer
 sudo systemctl daemon-reload
 sudo systemctl enable --now birdframe.timer  # --now starts it immediately, not only on the next boot
 
+if [ "$CONFIG_EXISTS" = 1 ]; then
+  cat <<DONE
+
+Installed. The existing frame source and settings in
+  $CONFIG
+were left unchanged. The frame refreshes every 15 minutes.
+DONE
+else
 case "$MODE" in
   local)
     cat <<DONE
@@ -195,32 +271,45 @@ and refreshes every 15 min, only when the birds change.
 DONE
     ;;
   birdweather)
-    cat <<DONE
+    if [ -n "$STATION_ID" ]; then
+      SOURCE_LABEL="BirdWeather station $STATION_ID"
+      MISSING_ARGS=(--station-id "$STATION_ID" --missing)
+      GENERATE_ARG="--station-id $STATION_ID"
+      cat <<DONE
 
-Installed in BirdWeather mode for ZIP $ZIP. The frame renders the top birds near
-you on the Pi and refreshes every 15 min, only when the local top birds change.
+Installed for BirdWeather station $STATION_ID. The frame renders that station's
+birds and refreshes every 15 min, only when its top birds change.
 DONE
-    # The bundled illustrations center on the western U.S. If birds near this ZIP
-    # aren't in the cloned set the frame quietly skips them, which has tripped
-    # people up - surface it here and point at the generator.
-    MISSING="$("$FRAME/.venv/bin/python" "$FRAME/birdweather.py" "$ZIP" --missing 2>/dev/null || true)"
+    else
+      SOURCE_LABEL="the area near $ZIP"
+      MISSING_ARGS=("$ZIP" --missing)
+      GENERATE_ARG="--zip $ZIP"
+      cat <<DONE
+
+Installed in BirdWeather ZIP mode for $ZIP. The frame renders the top birds near
+you and refreshes every 15 min, only when the local top birds change.
+DONE
+    fi
+    # Surface drawable-species gaps and point at the matching generator mode.
+    MISSING="$("$FRAME/.venv/bin/python" "$FRAME/birdweather.py" "${MISSING_ARGS[@]}" 2>/dev/null || true)"
     if [ -n "$MISSING" ]; then
       N="$(printf '%s\n' "$MISSING" | grep -c . || true)"
       NAMES="$(printf '%s\n' "$MISSING" | head -8 | sed 's/.*|/    /')"
       if [ "$N" -gt 8 ]; then NAMES="$NAMES
     ... and $((N - 8)) more"; fi
       cat <<FLAG
-Heads up: $N local bird(s) near you aren't in the illustration set you cloned, so
+Heads up: $N bird(s) from $SOURCE_LABEL aren't in the illustration set you cloned, so
 the frame will skip them:
 $NAMES
 To add them, run this on a laptop or workstation (it needs rembg, which the Pi
 can't fit) and commit or copy the new cutouts over:
-  python3 $FRAME/generate_illustrations.py --zip $ZIP --gemini-key <KEY>
+  python3 $FRAME/generate_illustrations.py $GENERATE_ARG --gemini-key <KEY>
 A paid Google Gemini API key is needed: https://ai.google.dev
 FLAG
     fi
     ;;
 esac
+fi
 
 # SPI only takes effect on a reboot, so do it for the user. Skip if SPI is
 # already up (e.g. a re-run) so we don't bounce a working frame.

--- a/frame/shoot.py
+++ b/frame/shoot.py
@@ -266,7 +266,7 @@ def shoot(url, out, *, title=None, subtitle=None, vw=600, vh=800, dsf=2,
             if subtitle is not None:
                 page.evaluate("s=>{const e=document.querySelector('.static-head h1'); if(e)e.textContent=s;}", subtitle)
             # Set the empty-state line for a birdless frame (the mic hasn't heard
-            # anything yet, or BirdWeather has no recent detections nearby) and
+            # anything yet, or BirdWeather has no recent detections) and
             # darken it so it survives the e-ink dither and the matting step's ink
             # detection (a no-op once there are birds). empty_text=None hides the
             # line entirely: the gen 3 frame shows the bare nest, no words.
@@ -298,12 +298,13 @@ def shoot_birdweather(out, species, *, title=None, subtitle=None, timeout_ms=450
     cutout_local = os.path.join(here, "..", "avian", "assets", "illustrations")
     # BirdWeather's flat 7-day counts need a steeper exponent for the same hero
     # hierarchy; the slightly smaller titles match the mic frame's optical weight.
-    # A birdless BirdWeather frame says "no recent detections nearby", not "listening".
+    # A birdless BirdWeather frame says "no recent detections", not "listening".
     for k, v in (("count_exp", 1.0), ("headline_px", 39), ("eyebrow_px", 17),
-                 ("empty_text", "no recent detections nearby")):
+                 ("empty_text", "no recent detections")):
         look.setdefault(k, v)
     return shoot(f"http://127.0.0.1:{port}/", out,
-                 title=title or "Avian Visitors", subtitle=subtitle or "Heard Today",
+                 title="Avian Visitors" if title is None else title,
+                 subtitle="Heard Today" if subtitle is None else subtitle,
                  species=species, cutout_base=RAW_ILLUSTRATIONS, cutout_local=cutout_local,
                  timeout_ms=timeout_ms, **look)
 
@@ -329,8 +330,9 @@ def main():
     ap.add_argument("--small-floor", type=float, default=0.04)
     ap.add_argument("--window-hours", type=int)
     ap.add_argument("--bird-weather", action="store_true",
-                    help="render from BirdWeather data for --zip instead of a local mic")
-    ap.add_argument("--zip", help="ZIP / postal code, required with --bird-weather")
+                    help="render from BirdWeather data for --zip or --station-id")
+    ap.add_argument("--zip", help="ZIP / postal code; use one BirdWeather locator")
+    ap.add_argument("--station-id", help="public numeric BirdWeather station ID")
     ap.add_argument("--bw-days", type=int, default=7, help="--bird-weather lookback window in days")
     ap.add_argument("--bw-country", default="us", help="--bird-weather geocoder country code")
     ap.add_argument("--width", type=int, default=600)
@@ -342,15 +344,23 @@ def main():
                     help="show common names along the birds")
     ap.add_argument("--timeout", type=int, default=45000)
     a = ap.parse_args()
+    if (a.zip or a.station_id) and not a.bird_weather:
+        print("--zip and --station-id only apply with --bird-weather", file=sys.stderr)
+        sys.exit(2)
     if a.bird_weather:
-        if not a.zip:
-            print("--bird-weather needs --zip", file=sys.stderr)
+        if bool(a.zip) == bool(a.station_id):
+            print("--bird-weather needs exactly one of --zip or --station-id", file=sys.stderr)
             sys.exit(2)
         sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
         import birdweather
-        species = birdweather.species_for_zip(a.zip, country=a.bw_country, days=a.bw_days)
+        if a.station_id:
+            species = birdweather.species_for_station(a.station_id, days=a.bw_days)
+            source = f"BirdWeather station {birdweather.station_id(a.station_id)}"
+        else:
+            species = birdweather.species_for_zip(a.zip, country=a.bw_country, days=a.bw_days)
+            source = f"ZIP {a.zip}"
         if not species:
-            print(f"no drawable birds near {a.zip}; nothing to render", file=sys.stderr)
+            print(f"no drawable birds for {source}; nothing to render", file=sys.stderr)
             sys.exit(3)
         # Pass the CLI's look flags through; shoot_birdweather fills the bird-weather
         # defaults (steeper count exponent, smaller titles) for anything left unset.

--- a/tests/test_frame_birdweather.py
+++ b/tests/test_frame_birdweather.py
@@ -1,0 +1,603 @@
+import importlib.util
+import contextlib
+import hashlib
+import io
+import json
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+FRAME = ROOT / "frame"
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FrameBirdWeatherTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.birdweather = load_module("frame_birdweather_test", FRAME / "birdweather.py")
+
+    def setUp(self):
+        self.birdweather._drawable = None
+
+    def dims_fixture(self, names):
+        temp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(temp.name)
+        (root / "dims.json").write_text(json.dumps({name: {} for name in names}), encoding="utf-8")
+        apt = root / "apt.js"
+        apt.write_text("", encoding="utf-8")
+        self.addCleanup(temp.cleanup)
+        return str(apt)
+
+    def test_station_id_accepts_only_canonical_public_ids(self):
+        station_id = self.birdweather.station_id
+        self.assertEqual(station_id("1"), "1")
+        self.assertEqual(station_id(2147483647), "2147483647")
+        for value in (None, "", 0, -1, True, 1.5, "01", " 1", "1 ",
+                      "https://app.birdweather.com/stations/1", "token-1",
+                      "1) { id }", "2147483648"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                station_id(value)
+
+    def test_exact_station_query_uses_variables_and_validates_identity(self):
+        seen = {}
+
+        def fake_graphql(query, timeout, variables=None, strict=False):
+            seen.update(query=query, timeout=timeout, variables=variables, strict=strict)
+            return {"data": {
+                "station": {"id": "314"},
+                "topSpecies": [
+                    {"count": 2, "species": {"commonName": "House Sparrow", "scientificName": "Passer domesticus"}},
+                    {"count": 8, "species": {"commonName": "American Crow", "scientificName": "Corvus brachyrhynchos"}},
+                ],
+            }}
+
+        with mock.patch.object(self.birdweather, "_graphql", side_effect=fake_graphql):
+            rows = self.birdweather.top_species_for_station("314", days=7, limit=60, timeout=9)
+        self.assertEqual([row["n"] for row in rows], [8, 2])
+        self.assertTrue(seen["strict"])
+        self.assertEqual(seen["timeout"], 9)
+        self.assertEqual(seen["variables"], {
+            "stationId": "314",
+            "stationIds": ["314"],
+            "period": {"count": 7, "unit": "day"},
+            "limit": 60,
+        })
+        self.assertNotIn("314", seen["query"])
+        self.assertNotIn("ne:", seen["query"])
+        self.assertNotIn("sw:", seen["query"])
+
+    def test_station_response_shape_is_fail_closed(self):
+        cases = (
+            {"data": {"station": None, "topSpecies": []}},
+            {"data": {"station": {"id": "315"}, "topSpecies": []}},
+            {"data": {"station": {"id": "314"}, "topSpecies": {}}},
+            {"data": {"station": {"id": "314"}, "topSpecies": [None]}},
+            {"data": {"station": {"id": "314"}, "topSpecies": [{"count": 0, "species": {"scientificName": "Passer domesticus"}}]}},
+            {"data": {"station": {"id": "314"}, "topSpecies": [{"count": 1, "species": {"scientificName": ""}}]}},
+        )
+        for payload in cases:
+            with self.subTest(payload=payload), \
+                    mock.patch.object(self.birdweather, "_graphql", return_value=payload), \
+                    self.assertRaises(self.birdweather.BirdWeatherError):
+                self.birdweather.top_species_for_station("314")
+
+    def test_valid_station_with_no_detections_is_an_empty_success(self):
+        payload = {"data": {"station": {"id": 314}, "topSpecies": []}}
+        with mock.patch.object(self.birdweather, "_graphql", return_value=payload):
+            self.assertEqual(self.birdweather.top_species_for_station(314), [])
+
+    def test_station_mode_filters_art_without_geographic_fallback(self):
+        apt = self.dims_fixture(("passer-domesticus", "corvus-brachyrhynchos"))
+        rows = [
+            {"sci": "Missing bird", "com": "Missing", "n": 20},
+            {"sci": "Corvus brachyrhynchos", "com": "American Crow", "n": 9},
+            {"sci": "Passer domesticus", "com": "House Sparrow", "n": 4},
+        ]
+        forbidden = mock.Mock(side_effect=AssertionError("station mode used a fallback"))
+        with mock.patch.object(self.birdweather, "top_species_for_station", return_value=rows), \
+                mock.patch.object(self.birdweather, "geocode", forbidden), \
+                mock.patch.object(self.birdweather, "triangulate", forbidden), \
+                mock.patch.object(self.birdweather, "ebird_nearby", forbidden):
+            result = self.birdweather.species_for_station("314", target=1, apt_js=apt)
+        self.assertEqual(result, [rows[1]])
+        forbidden.assert_not_called()
+
+    def test_station_coverage_splits_drawable_and_missing(self):
+        apt = self.dims_fixture(("passer-domesticus",))
+        rows = [
+            {"sci": "Passer domesticus", "com": "House Sparrow", "n": 5},
+            {"sci": "Corvus brachyrhynchos", "com": "American Crow", "n": 4},
+        ]
+        with mock.patch.object(self.birdweather, "top_species_for_station", return_value=rows):
+            have, missing = self.birdweather.coverage_for_station("314", apt_js=apt)
+        self.assertEqual(have, [rows[0]])
+        self.assertEqual(missing, [rows[1]])
+
+    def test_strict_transport_rejects_errors_and_oversized_bodies(self):
+        class Response:
+            def __init__(self, body):
+                self.body = body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, _limit):
+                return self.body
+
+        for body in (b'{"errors":[{"message":"no"}]}', b"x" * 2_000_001):
+            with self.subTest(size=len(body)), \
+                    mock.patch.object(self.birdweather.urllib.request, "urlopen", return_value=Response(body)), \
+                    self.assertRaises(self.birdweather.BirdWeatherError):
+                self.birdweather._graphql("query Test { station(id: 1) { id } }", 1, strict=True)
+
+
+class FrameDisplayTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.birdweather = load_module("birdweather", FRAME / "birdweather.py")
+        sys.modules["birdweather"] = cls.birdweather
+        if sys.version_info < (3, 11):
+            sys.modules.setdefault("tomli", types.SimpleNamespace(load=lambda _stream: {}))
+        cls.display = load_module("frame_display_test", FRAME / "display.py")
+
+    def config(self, **updates):
+        cfg = dict(self.display.DEFAULTS)
+        cfg.update(species_source="birdweather", **updates)
+        return cfg
+
+    def test_display_routes_station_and_preserves_zip_mode(self):
+        with mock.patch.object(self.birdweather, "species_for_station", return_value=[]) as station, \
+                mock.patch.object(self.birdweather, "species_for_zip", return_value=[]) as zip_mode:
+            self.assertEqual(self.display.fetch_species(self.config(bw_station_id="314")), [])
+            station.assert_called_once_with("314", days=7)
+            zip_mode.assert_not_called()
+
+        with mock.patch.object(self.birdweather, "species_for_station", return_value=[]) as station, \
+                mock.patch.object(self.birdweather, "species_for_zip", return_value=[]) as zip_mode:
+            self.assertEqual(self.display.fetch_species(self.config(zip="94107")), [])
+            zip_mode.assert_called_once_with("94107", country="us", days=7)
+            station.assert_not_called()
+
+    def test_display_rejects_ambiguous_or_missing_birdweather_locator(self):
+        for cfg in (self.config(), self.config(zip="94107", bw_station_id="314")):
+            with self.subTest(cfg=cfg), self.assertRaises(ValueError):
+                self.display.fetch_species(cfg)
+
+    def test_station_identity_is_part_of_change_signature(self):
+        species = [{"sci": "Passer domesticus", "n": 5}]
+        first = self.display.signature(species, self.display.birdweather_signature_scope(
+            self.config(bw_station_id="314")))
+        second = self.display.signature(species, self.display.birdweather_signature_scope(
+            self.config(bw_station_id="315")))
+        self.assertNotEqual(first, second)
+
+    def test_unscoped_signature_stays_compatible_with_existing_frames(self):
+        species = [{"sci": "Passer domesticus", "n": 5}]
+        items = [("passer-domesticus", self.display._bucket(5))]
+        expected = hashlib.sha256(json.dumps(items).encode()).hexdigest()[:16]
+        self.assertEqual(self.display.signature(species), expected)
+
+
+class FrameShootTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        playwright = types.ModuleType("playwright")
+        sync_api = types.ModuleType("playwright.sync_api")
+        sync_api.TimeoutError = RuntimeError
+        sync_api.sync_playwright = lambda: None
+        sys.modules.setdefault("playwright", playwright)
+        sys.modules.setdefault("playwright.sync_api", sync_api)
+        cls.shoot = load_module("frame_shoot_test", FRAME / "shoot.py")
+
+    def test_birdweather_title_defaults_do_not_override_empty_strings(self):
+        calls = []
+        with mock.patch.object(self.shoot, "_serve_frontend", return_value=(object(), 1234)), \
+                mock.patch.object(self.shoot, "shoot", side_effect=lambda *args, **kwargs: calls.append(kwargs)):
+            self.shoot.shoot_birdweather("out.png", [], title="", subtitle="")
+            self.shoot.shoot_birdweather("out.png", [], title=None, subtitle=None)
+        self.assertEqual((calls[0]["title"], calls[0]["subtitle"]), ("", ""))
+        self.assertEqual((calls[1]["title"], calls[1]["subtitle"]),
+                         ("Avian Visitors", "Heard Today"))
+
+
+class FrameGeneratorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.birdweather = sys.modules.get("birdweather") or load_module(
+            "birdweather", FRAME / "birdweather.py")
+        sys.modules["birdweather"] = cls.birdweather
+        cls.generator = load_module("frame_generator_test", FRAME / "generate_illustrations.py")
+
+    def test_generator_routes_station_and_preserves_zip_mode(self):
+        with mock.patch.object(self.birdweather, "coverage_for_station", return_value=([{}], [])) as station, \
+                mock.patch.object(sys, "argv", ["generate_illustrations.py", "--station-id", "314"]), \
+                contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(self.generator.main(), 0)
+            station.assert_called_once_with("314", 15)
+
+        with mock.patch.object(self.birdweather, "coverage_for_zip", return_value=([{}], [])) as zip_mode, \
+                mock.patch.object(sys, "argv", ["generate_illustrations.py", "--zip", "94107"]), \
+                contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(self.generator.main(), 0)
+            zip_mode.assert_called_once_with("94107", "us", 15)
+
+    def test_generator_requires_exactly_one_locator(self):
+        for args in ([], ["--zip", "94107", "--station-id", "314"]):
+            with self.subTest(args=args), mock.patch.object(
+                    sys, "argv", ["generate_illustrations.py", *args]), \
+                    contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit) as raised:
+                self.generator.main()
+            self.assertEqual(raised.exception.code, 2)
+
+
+class FrameInstallerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        candidates = (sys.executable, shutil.which("python3.11"), shutil.which("python3"))
+        cls.config_python = None
+        for candidate in candidates:
+            if not candidate or candidate == cls.config_python:
+                continue
+            probe = subprocess.run(
+                [candidate, "-c", "try:\n import tomllib\nexcept ModuleNotFoundError:\n import tomli"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if probe.returncode == 0:
+                cls.config_python = candidate
+                break
+        if cls.config_python is None:
+            raise unittest.SkipTest("frame config tests need Python tomllib or tomli")
+
+    def make_fixture(self):
+        temp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(temp.name)
+        frame = root / "frame"
+        frame.mkdir()
+        (frame / "systemd").mkdir()
+        for name in ("install.sh", "requirements-frame.txt", "birdweather.py",
+                     "config_contract.py", "birdframe-names"):
+            shutil.copy2(FRAME / name, frame / name)
+        for name in ("birdframe.service", "birdframe.timer"):
+            shutil.copy2(FRAME / "systemd" / name, frame / "systemd" / name)
+
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        sudo = bin_dir / "sudo"
+        sudo.write_text(
+            "#!/usr/bin/env bash\n"
+            "if [ \"${1:-}\" = tee ]; then cat >/dev/null; fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        python = bin_dir / "python3"
+        python.write_text(
+            "#!/usr/bin/env bash\n"
+            "case \" $* \" in\n"
+            "  *\"config_contract.py \"*) exec \"$BIRDFRAME_TEST_REAL_PYTHON\" \"$@\" ;;\n"
+            "esac\n"
+            "case \" $* \" in\n"
+            "  *\"import tomllib\"*|*\"import tomli\"*) "
+            "[ \"${BIRDFRAME_TEST_SYSTEM_TOML_FAIL:-0}\" = 1 ] && exit 1 ;;\n"
+            "esac\n"
+            "case \" $* \" in\n"
+            "  *\" --check-station \"*) [ \"${BIRDFRAME_TEST_STATION_FAIL:-0}\" = 1 ] && exit 1 ;;\n"
+            "esac\n"
+            "if [ \"${1:-}\" = -m ] && [ \"${2:-}\" = venv ]; then\n"
+            "  mkdir -p \"$3/bin\"\n"
+            "  for tool in pip playwright python; do\n"
+            "    printf '#!/usr/bin/env bash\\nexit 0\\n' > \"$3/bin/$tool\"\n"
+            "    chmod +x \"$3/bin/$tool\"\n"
+            "  done\n"
+            "fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        sleep = bin_dir / "sleep"
+        sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        for path in (sudo, python, sleep):
+            path.chmod(path.stat().st_mode | stat.S_IXUSR)
+        home = root / "home"
+        home.mkdir()
+        self.addCleanup(temp.cleanup)
+        return frame, home, bin_dir
+
+    def run_install(self, *args, existing=None, extra_env=None, existing_venv=False):
+        frame, home, bin_dir = self.make_fixture()
+        if existing_venv:
+            venv_bin = frame / ".venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            venv_python = venv_bin / "python"
+            venv_python.write_text(
+                "#!/usr/bin/env bash\nexec \"$BIRDFRAME_TEST_REAL_PYTHON\" \"$@\"\n",
+                encoding="utf-8",
+            )
+            venv_python.chmod(venv_python.stat().st_mode | stat.S_IXUSR)
+        if existing is not None:
+            config_dir = home / ".birdframe"
+            config_dir.mkdir()
+            (config_dir / "config.toml").write_text(existing, encoding="utf-8")
+        env = dict(os.environ, HOME=str(home), USER="reviewer",
+                   BIRDFRAME_TEST_REAL_PYTHON=self.config_python,
+                   PATH=str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
+        env.update(extra_env or {})
+        result = subprocess.run(
+            ["bash", str(frame / "install.sh"), *args],
+            cwd=frame,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=20,
+            check=False,
+        )
+        config = home / ".birdframe" / "config.toml"
+        return result, config.read_text(encoding="utf-8") if config.exists() else ""
+
+    def test_station_id_alone_writes_exact_station_config(self):
+        result, config = self.run_install("--station-id", "314")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn('species_source = "birdweather"', config)
+        self.assertIn('bw_station_id = "314"', config)
+        self.assertNotRegex(config, r"(?m)^zip\s*=")
+        self.assertNotIn("bw_country", config)
+        self.assertIn("Installed for BirdWeather station 314", result.stdout)
+
+        explicit, explicit_config = self.run_install("--bird-weather", "--station-id=314")
+        self.assertEqual(explicit.returncode, 0, explicit.stdout)
+        self.assertEqual(config, explicit_config)
+
+    def test_fresh_zip_and_image_modes_keep_their_configs(self):
+        zip_result, zip_config = self.run_install("--bird-weather", "--zip", "94107")
+        self.assertEqual(zip_result.returncode, 0, zip_result.stdout)
+        self.assertIn('zip = "94107"', zip_config)
+        self.assertIn('bw_country = "us"', zip_config)
+        self.assertNotIn("bw_station_id", zip_config)
+
+        image_result, image_config = self.run_install(
+            "--image-url", "https://bird.example/frame.png?k=review")
+        self.assertEqual(image_result.returncode, 0, image_result.stdout)
+        self.assertIn('image_url = "https://bird.example/frame.png?k=review"', image_config)
+        self.assertNotIn('species_source = "birdweather"', image_config)
+
+    def test_existing_source_must_match_the_requested_zip_or_image(self):
+        zip_config = ('# birdframe-mode: birdweather\n'
+                      'species_source = "birdweather"\n'
+                      'zip = "94107"\n'
+                      'bw_country = "us"\n')
+        same_zip, unchanged = self.run_install(
+            "--bird-weather", "--zip", "94107", existing=zip_config)
+        self.assertEqual(same_zip.returncode, 0, same_zip.stdout)
+        self.assertEqual(unchanged, zip_config)
+
+        for args in (("--bird-weather", "--zip", "10001"), ("--station-id", "314")):
+            with self.subTest(args=args):
+                result, unchanged = self.run_install(*args, existing=zip_config)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertNotIn("1/5", result.stdout)
+                self.assertEqual(unchanged, zip_config)
+
+        image_config = ('# birdframe-mode: image\n'
+                        'image_url = "https://bird.example/old.png"\n'
+                        'shoot = false\n')
+        same_image, unchanged = self.run_install(
+            "--image-url", "https://bird.example/old.png", existing=image_config)
+        self.assertEqual(same_image.returncode, 0, same_image.stdout)
+        self.assertEqual(unchanged, image_config)
+
+        different_image, unchanged = self.run_install(
+            "--image-url", "https://bird.example/new.png", existing=image_config)
+        self.assertNotEqual(different_image.returncode, 0, different_image.stdout)
+        self.assertNotIn("1/5", different_image.stdout)
+        self.assertEqual(unchanged, image_config)
+
+    def test_existing_supported_custom_sources_remain_upgradeable(self):
+        custom_local = ('# birdframe-mode: local\n'
+                        'base_url = "https://birds.example.test"\n'
+                        'shoot = true\n')
+        result, unchanged = self.run_install(existing=custom_local)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(unchanged, custom_local)
+
+        for bad_url in ("http://", "https://?x=1", "http:// bad host", "https://[broken"):
+            with self.subTest(bad_url=bad_url):
+                invalid_local = ('base_url = "' + bad_url + '"\nshoot = true\n')
+                result, unchanged = self.run_install(existing=invalid_local)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertNotIn("1/5", result.stdout)
+                self.assertEqual(unchanged, invalid_local)
+
+        local_image = ('image = "~/.birdframe/frame.png"\n'
+                       'shoot = false\n')
+        result, unchanged = self.run_install(existing=local_image)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(unchanged, local_image)
+
+        international_zip = ('# birdframe-mode: birdweather\n'
+                             'species_source = "birdweather"\n'
+                             'zip = "SW1A 1AA"\n'
+                             'bw_country = "gb"\n')
+        result, unchanged = self.run_install(
+            "--bird-weather", "--zip", "SW1A 1AA", existing=international_zip)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(unchanged, international_zip)
+
+        markerless_station = ('species_source = "birdweather"\n'
+                              'bw_station_id = "314"\n')
+        result, unchanged = self.run_install(
+            "--station-id", "314", existing=markerless_station)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(unchanged, markerless_station)
+
+    def test_existing_config_source_must_be_unambiguous_and_effective(self):
+        malformed_station_configs = (
+            '# birdframe-mode: birdweather\nbw_station_id = "314"\n',
+            '# birdframe-mode: birdweather\nspecies_source = "birdweather"\n[wrong]\nbw_station_id = "314"\n',
+            '# birdframe-mode: birdweather\nspecies_source = "birdweather"\nbw_station_id = "314\n',
+            ('# birdframe-mode: birdweather\nspecies_source = "birdweather"\n'
+             'bw_station_id = "313"\nbw_station_id = "314"\n'),
+            ('# birdframe-mode: birdweather\nnotes = """\n'
+             'species_source = "birdweather"\nbw_station_id = "314"\n"""\n'),
+            ('# birdframe-mode: birdweather\nspecies_source = "birdweather"\n'
+             'bw_station_id = "314"\n"zip" = "94107"\n'),
+            ('# birdframe-mode: birdweather\nspecies_source = "birdweather"\n'
+             'bw_station_id = "314"\nbw_station_id.extra = "x"\n'),
+        )
+        for existing in malformed_station_configs:
+            with self.subTest(existing=existing):
+                result, unchanged = self.run_install(
+                    "--station-id", "314", existing=existing)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertNotIn("1/5", result.stdout)
+                self.assertEqual(unchanged, existing)
+
+        malformed_zip = ('# birdframe-mode: birdweather\n'
+                         'zip = "94107"\n'
+                         'bw_country = "us"\n')
+        result, unchanged = self.run_install(
+            "--bird-weather", "--zip", "94107", existing=malformed_zip)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(unchanged, malformed_zip)
+
+        ineffective_image = ('# birdframe-mode: image\n'
+                              'image_url = "https://bird.example/frame.png"\n'
+                              'shoot = true\n')
+        result, unchanged = self.run_install(
+            "--image-url", "https://bird.example/frame.png", existing=ineffective_image)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(unchanged, ineffective_image)
+
+        disguised_image = ('# birdframe-mode: image\n'
+                           'image_url = "https://bird.example/frame.png"\n'
+                           'shoot = false\n'
+                           '"species_source" = "birdweather"\n'
+                           '"bw_station_id" = "314"\n')
+        result, unchanged = self.run_install(
+            "--image-url", "https://bird.example/frame.png", existing=disguised_image)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(unchanged, disguised_image)
+
+        local_config = ('# birdframe-mode: local\n'
+                        'base_url = "http://birdnet.local"\n'
+                        'shoot = true\n')
+        same_local, unchanged = self.run_install(existing=local_config)
+        self.assertEqual(same_local.returncode, 0, same_local.stdout)
+        self.assertEqual(unchanged, local_config)
+
+        disguised_local = local_config + ('species_source = "birdweather"\n'
+                                          'bw_station_id = "314"\n')
+        result, unchanged = self.run_install(existing=disguised_local)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(unchanged, disguised_local)
+
+        malformed_preserved_image = ('image_url = { hidden = "source" }\n'
+                                     'image = "/tmp/frame.png"\n'
+                                     'shoot = false\n')
+        result, unchanged = self.run_install(existing=malformed_preserved_image)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(unchanged, malformed_preserved_image)
+
+    def test_station_mode_rejects_conflicts_and_invalid_ids_before_install(self):
+        cases = (
+            ("--station-id", "0"),
+            ("--station-id", "01"),
+            ("--station-id", " 1"),
+            ("--station-id", "token"),
+            ("--station-id", "2147483648"),
+            ("--bird-weather", "--zip", "94107 "),
+            ("--station-id", "314", "--zip", "94107"),
+            ("--zip", "94107", "--station-id", "314"),
+            ("--station-id", "314", "--ebird-key", "ABC"),
+            ("--station-id", "314", "--image-url", "https://example.test/frame.png"),
+        )
+        for args in cases:
+            with self.subTest(args=args):
+                result, config = self.run_install(*args)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(config, "")
+                self.assertNotIn("1/5", result.stdout)
+
+    def test_existing_config_cannot_claim_a_different_station(self):
+        existing = '# birdframe-mode: birdweather\nspecies_source = "birdweather"\nbw_station_id = "313"\n'
+        result, config = self.run_install("--station-id", "314", existing=existing)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("does not select BirdWeather station 314", result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(config, existing)
+
+        ambiguous = existing.replace('bw_station_id = "313"',
+                                     'bw_station_id = "314"\nzip = "94107"')
+        result, config = self.run_install("--station-id", "314", existing=ambiguous)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(config, ambiguous)
+
+    def test_existing_matching_station_is_left_untouched(self):
+        existing = ('# birdframe-mode: birdweather\n'
+                    'species_source = "birdweather"\n'
+                    'bw_station_id = "314"\n'
+                    'shoot_title = "Backyard birds"\n')
+        result, config = self.run_install("--station-id", "314", existing=existing)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("already exists, leaving it untouched", result.stdout)
+        self.assertEqual(config, existing)
+
+        offline, unchanged = self.run_install(
+            "--station-id", "314", existing=existing,
+            extra_env={"BIRDFRAME_TEST_STATION_FAIL": "1"})
+        self.assertEqual(offline.returncode, 0, offline.stdout)
+        self.assertNotIn("Checking public BirdWeather station", offline.stdout)
+        self.assertEqual(unchanged, existing)
+
+    def test_existing_config_uses_prior_venv_parser_or_fails_before_mutation(self):
+        existing = ('# birdframe-mode: birdweather\n'
+                    'species_source = "birdweather"\n'
+                    'bw_station_id = "314"\n')
+        no_parser, unchanged = self.run_install(
+            "--station-id", "314", existing=existing,
+            extra_env={"BIRDFRAME_TEST_SYSTEM_TOML_FAIL": "1"})
+        self.assertNotEqual(no_parser.returncode, 0, no_parser.stdout)
+        self.assertIn("without Python tomllib or tomli", no_parser.stdout)
+        self.assertNotIn("1/5", no_parser.stdout)
+        self.assertEqual(unchanged, existing)
+
+        prior_venv, unchanged = self.run_install(
+            "--station-id", "314", existing=existing, existing_venv=True,
+            extra_env={"BIRDFRAME_TEST_SYSTEM_TOML_FAIL": "1"})
+        self.assertEqual(prior_venv.returncode, 0, prior_venv.stdout)
+        self.assertEqual(unchanged, existing)
+
+    def test_unavailable_station_stops_before_host_mutation(self):
+        result, config = self.run_install(
+            "--station-id", "314", extra_env={"BIRDFRAME_TEST_STATION_FAIL": "1"})
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("could not be verified", result.stdout)
+        self.assertNotIn("1/5", result.stdout)
+        self.assertEqual(config, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add frame/install.sh --station-id <ID> for one public BirdWeather station
- keep station mode exact, with no ZIP, nearby-station, or eBird fallback
- validate fresh station IDs and existing TOML source semantics before host changes
- preserve existing ZIP, local mic, image, custom URL, and non-US configurations
- make an empty frame title behave consistently in mic and BirdWeather modes
- document the public station ID, illustration workflow, and existing opening geometry

## Testing

- 24 exact-station and frame installer tests
- 22 existing BirdWeather, reporting, and installer regression tests
- Python compilation and Bash syntax
- whitespace and copy scans
- two independent adversarial reviews with no remaining P0 to P2 findings