### PR TITLE
Fix fresh install webroot ordering

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -119,6 +119,24 @@ EOF
   systemctl enable birdnet_analysis.service
 }
 
+prepare_caddy_webroot() {
+  echo "Preparing BirdNET-Pi webroot"
+  [[ "${BIRDNET_USER}" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]] \
+    && getent passwd "${BIRDNET_USER}" >/dev/null \
+    || { echo "Invalid BirdNET-Pi user" >&2; return 1; }
+  [[ "${EXTRACTED}" =~ ^/[A-Za-z0-9._/-]+$ ]] \
+    && [ "${EXTRACTED}" != / ] && [[ "${EXTRACTED}" != *'..'* ]] \
+    || { echo "Invalid BirdNET-Pi webroot" >&2; return 1; }
+  if ! sudo -u "${BIRDNET_USER}" mkdir -p -- "${EXTRACTED}"; then
+    echo "Could not create the BirdNET-Pi webroot" >&2
+    return 1
+  fi
+  [ -d "${EXTRACTED}" ] \
+    && sudo -u "${BIRDNET_USER}" test -w "${EXTRACTED}" \
+    && sudo -u "${BIRDNET_USER}" test -x "${EXTRACTED}" \
+    || { echo "BirdNET-Pi webroot is not writable" >&2; return 1; }
+}
+
 create_necessary_dirs() {
   echo "Creating necessary directories"
   [ -d ${EXTRACTED} ] || sudo -u ${USER} mkdir -p ${EXTRACTED}
@@ -417,6 +435,7 @@ install_services() {
   install_depends
   install_scripts
   install_avian_controls
+  prepare_caddy_webroot
   install_Caddyfile
   install_avahi_aliases
   install_birdnet_analysis

--- a/tests/smoke_install_clear.sh
+++ b/tests/smoke_install_clear.sh
@@ -142,6 +142,8 @@ cat >"$repo/scripts/update_caddyfile.sh" <<'EOF'
 if [ -e /tmp/avian-release-flow/fail-caddy ]; then
   exit 1
 fi
+[ -d /home/bird/BirdSongs/Extracted ] \
+  || { echo "webroot missing before Caddy render" >&2; exit 1; }
 touch /tmp/avian-release-flow/caddy.called
 printf 'caddy\n' >>/tmp/avian-release-flow/service-order.log
 EOF
@@ -256,18 +258,59 @@ grep -q "Refusing to replace directory: $collision_root/fonts" "$test_root/colli
   || fail "directory collision did not report its target"
 
 # Clean overlay installation. Source the installer with no repository config
-# so only the two bounded functions below run.
+# so only the bounded functions below run.
+[ ! -e "$extracted" ] || fail "fresh-install webroot already exists"
 (
-  my_dir=$repo
   USER=bird
   HOME=$bird_home
-  RECS_DIR=$recordings
-  EXTRACTED=$extracted
-  PROCESSED=$processed
+  export BIRDNET_USER=bird
+  export RECS_DIR=$recordings
+  export EXTRACTED=$extracted
+  export PROCESSED=$processed
   source "$repo/scripts/install_services.sh"
   install_avian_controls
+  prepare_caddy_webroot
+  [ "$(stat -c '%U:%G' "$EXTRACTED")" = bird:bird ] \
+    || fail "fresh-install webroot has the wrong owner"
+  install_Caddyfile
+  prepare_caddy_webroot
   create_necessary_dirs
 )
+
+[ -e "$test_root/caddy.called" ] \
+  || fail "Caddy was not rendered after webroot preparation"
+: >"$test_root/systemctl.log"
+chown bird:bird "$test_root/systemctl.log"
+
+unsafe_webroot=$test_root/unsafe-webroot
+printf 'not a directory\n' >"$unsafe_webroot"
+chown bird:bird "$unsafe_webroot"
+(
+  USER=bird
+  HOME=$bird_home
+  export BIRDNET_USER=bird
+  export EXTRACTED=$unsafe_webroot
+  source "$repo/scripts/install_services.sh"
+  if prepare_caddy_webroot >"$test_root/unsafe-webroot.log" 2>&1; then
+    fail "fresh-install preparation accepted a file as the webroot"
+  fi
+)
+grep -Fq "Could not create the BirdNET-Pi webroot" \
+  "$test_root/unsafe-webroot.log" \
+  || fail "unsafe fresh-install webroot returned the wrong error"
+
+(
+  USER=bird
+  HOME=$bird_home
+  export BIRDNET_USER=bird
+  export EXTRACTED=/
+  source "$repo/scripts/install_services.sh"
+  if prepare_caddy_webroot >"$test_root/root-webroot.log" 2>&1; then
+    fail "fresh-install preparation accepted the filesystem root"
+  fi
+)
+grep -Fq "Invalid BirdNET-Pi webroot" "$test_root/root-webroot.log" \
+  || fail "invalid fresh-install webroot returned the wrong error"
 
 assert_avian_runtime_links
 assert_stock_runtime_links

--- a/tests/test_lan_admin_auth.py
+++ b/tests/test_lan_admin_auth.py
@@ -80,6 +80,11 @@ class LanAdminAuthStaticTests(unittest.TestCase):
         init = install.index("auth-state-init")
         caddy = install.index("install_Caddyfile")
         self.assertLess(init, caddy)
+        flow = install[install.index("install_services() {") :]
+        self.assertLess(
+            flow.index("prepare_caddy_webroot"),
+            flow.index("install_Caddyfile"),
+        )
         self.assertIn("auth-state-init", self.read("scripts/security_refresh.sh"))
 
     def test_caddy_uses_state_and_closes_required_surfaces(self):


### PR DESCRIPTION
## What changed

- Create the configured webroot as the BirdNET-Pi user before the first Caddy render.
- Keep the existing Caddy path validation and fail closed for invalid or unwritable paths.
- Cover fresh, repeated, file collision, and filesystem root cases.

## Tests

- Full install and clear smoke in a disposable container
- Installer regression smoke
- LAN and Educators security tests
- ShellCheck and shell syntax
- Diff and Unicode dash checks